### PR TITLE
fix: pass requireAuth to admin routes, include cms_sessions in init migration

### DIFF
--- a/packages/cms/src/__tests__/cms-config.test.ts
+++ b/packages/cms/src/__tests__/cms-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { buildCms } from '../config/cms-config.js'
 import type { CmsConfig } from '../config/cms-config.js'
 import type { Plugin } from '../config/plugin.js'
@@ -161,5 +161,53 @@ describe('CmsInstance', () => {
     const cms = buildCms(config)._unsafeUnwrap()
     expect(cms.restRoutes.has('/media/upload')).toBe(true)
     expect(cms.restRoutes.has('/media/:filename')).toBe(true)
+  })
+})
+
+describe('buildCms() requireAuth forwarding', () => {
+  it('forwards requireAuth to admin routes so handlers check session', async () => {
+    const config: CmsConfig = {
+      db: makeMockPool(),
+      secret: 'test-secret',
+      requireAuth: true,
+      collections: [
+        collection({ slug: 'posts', fields: [field.text({ name: 'title' })] })
+      ]
+    }
+    const cms = buildCms(config)._unsafeUnwrap()
+    const handler = cms.adminRoutes.get('/admin')?.GET
+    expect(handler).toBeDefined()
+
+    const req = { headers: {}, url: '/admin', method: 'GET' }
+    const res = {
+      writeHead: vi.fn(),
+      end: vi.fn(),
+      setHeader: vi.fn()
+    }
+    await handler!(req as never, res as never, {})
+    expect(res.writeHead).toHaveBeenCalledWith(302, { Location: '/admin/login' })
+  })
+
+  it('admin routes work without auth when requireAuth is not set', async () => {
+    const config: CmsConfig = {
+      db: makeMockPool(),
+      secret: 'test-secret',
+      collections: [
+        collection({ slug: 'posts', fields: [field.text({ name: 'title' })] })
+      ]
+    }
+    const cms = buildCms(config)._unsafeUnwrap()
+    const handler = cms.adminRoutes.get('/admin')?.GET
+    expect(handler).toBeDefined()
+
+    const req = { headers: {}, url: '/admin', method: 'GET' }
+    const res = {
+      writeHead: vi.fn(),
+      end: vi.fn((data: string) => {}),
+      setHeader: vi.fn()
+    }
+    await handler!(req as never, res as never, {})
+    // Should return 200 (renders dashboard), not redirect
+    expect(res.writeHead).toHaveBeenCalledWith(200)
   })
 })

--- a/packages/cms/src/config/cms-config.ts
+++ b/packages/cms/src/config/cms-config.ts
@@ -25,6 +25,7 @@ export interface CmsConfig {
   readonly globals?: readonly GlobalConfig[] | undefined
   readonly plugins?: readonly Plugin[] | undefined
   readonly uploadDir?: string | undefined
+  readonly requireAuth?: boolean | undefined
   readonly telemetryPool?: DbPool | undefined
   readonly headTags?: readonly string[] | undefined
 }
@@ -60,7 +61,7 @@ export function buildCms (inputConfig: CmsConfig): Result<CmsInstance, CmsError>
 
   const api = createLocalApi(config.db, collections, globals)
   const restRoutes = createRestRoutes(config.db, collections, globals)
-  const adminRoutes = createAdminRoutes(config.db, collections, { telemetryPool: config.telemetryPool, headTags: config.headTags })
+  const adminRoutes = createAdminRoutes(config.db, collections, { requireAuth: config.requireAuth, telemetryPool: config.telemetryPool, headTags: config.headTags })
 
   const hasAuthCollection = config.collections.some(c => isAuthEnabled(c))
   if (hasAuthCollection) {

--- a/packages/valence/src/__tests__/init-template.test.ts
+++ b/packages/valence/src/__tests__/init-template.test.ts
@@ -124,3 +124,27 @@ describe('init migration SQL', () => {
     expect(sql).toContain('CREATE TABLE IF NOT EXISTS "document_revisions"')
   })
 })
+
+describe('init migration cms_sessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('migration includes cms_sessions table for admin auth', async () => {
+    await run(['init', 'test-app', '-y'])
+    const sql = getWrittenFile('001-init.sql')
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "cms_sessions"')
+  })
+
+  it('cms_sessions table has user_id FK, expires_at, and deleted_at columns', async () => {
+    await run(['init', 'test-app', '-y'])
+    const sql = getWrittenFile('001-init.sql')
+    expect(sql).toContain('"user_id" UUID NOT NULL REFERENCES "users"("id")')
+    expect(sql).toContain('"expires_at" TIMESTAMPTZ NOT NULL')
+    expect(sql).toContain('"deleted_at" TIMESTAMPTZ')
+  })
+})

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -236,6 +236,14 @@ CREATE TABLE IF NOT EXISTS "users" (
 );
 
 
+CREATE TABLE IF NOT EXISTS "cms_sessions" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" UUID NOT NULL REFERENCES "users"("id"),
+  "expires_at" TIMESTAMPTZ NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "deleted_at" TIMESTAMPTZ
+);
+
 CREATE TABLE IF NOT EXISTS "document_revisions" (
   "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   "collection_slug" TEXT NOT NULL,


### PR DESCRIPTION
## Summary

- **buildCms requireAuth forwarding**: `CmsConfig.requireAuth` was not being passed through to `createAdminRoutes`, so even when callers set `requireAuth: true`, admin routes were unprotected. Added the field to `CmsConfig` and forwarded it in the `createAdminRoutes` call.
- **cms_sessions table in init migration**: The `001-init.sql` template created by `valence init` was missing the `cms_sessions` table that `session.ts` queries. Admin login would fail with a "relation cms_sessions does not exist" error on fresh projects. Added the table definition after the `users` table with proper FK reference.
- **ctx.id vs params.id (Bug 2)**: Investigated and confirmed this is already correct — `matchRoute` returns flat `params: { id }` and handlers receive it as `ctx`, so `ctx.id` works as expected.

## Test plan

- [x] Added test: `buildCms()` with `requireAuth: true` produces admin routes that redirect to `/admin/login` without a session cookie
- [x] Added test: `buildCms()` without `requireAuth` serves admin routes normally (200)
- [x] Added test: init migration SQL includes `cms_sessions` table
- [x] Added test: `cms_sessions` table has `user_id` FK, `expires_at`, and `deleted_at` columns
- [x] All 635 cms + valence tests pass
- [x] Pre-push hooks (build + smoke tests) pass