### PR TITLE
fix: resolve auth display field from collection config instead of hardcoding name

### DIFF
--- a/packages/cms/src/__tests__/auth-routes.test.ts
+++ b/packages/cms/src/__tests__/auth-routes.test.ts
@@ -147,4 +147,15 @@ describe('resolveDisplayField()', () => {
     }))
     expect(resolveDisplayField(registry)).toBe('display_name')
   })
+
+  it('result is always a valid identifier', () => {
+    const registry = createCollectionRegistry()
+    registry.register(collection({
+      slug: 'users',
+      auth: true,
+      fields: [field.text({ name: 'username' })]
+    }))
+    const result = resolveDisplayField(registry)
+    expect(result).toMatch(/^[a-zA-Z][a-zA-Z0-9_-]*$/)
+  })
 })

--- a/packages/cms/src/auth/auth-routes.ts
+++ b/packages/cms/src/auth/auth-routes.ts
@@ -11,14 +11,13 @@ import { createRateLimiter } from './rate-limit.js'
 import { parseCookie } from './cookie.js'
 import { safeQuery } from '../db/safe-query.js'
 import { createSession, validateSession, destroySession, buildSessionCookie, buildExpiredSessionCookie } from './session.js'
-import { sanitizeIdentifier } from '../db/sql-sanitize.js'
+import { sanitizeIdentifier, isValidIdentifier } from '../db/sql-sanitize.js'
 import { isAuthEnabled } from './auth-config.js'
 
 interface UserRow {
   readonly id: string
   readonly email: string
   readonly password_hash: string
-  readonly [key: string]: string
 }
 
 const loginSchema = z.object({
@@ -49,7 +48,8 @@ export function createAuthRoutes (
   pool: DbPool,
   collections: CollectionRegistry
 ): Map<string, RestRouteEntry> {
-  const displayField = resolveDisplayField(collections)
+  const rawDisplayField = resolveDisplayField(collections)
+  const displayField = isValidIdentifier(rawDisplayField) ? rawDisplayField : 'email'
   const safeDisplayCol = sanitizeIdentifier(displayField)
   const routes = new Map<string, RestRouteEntry>()
   const loginLimiter = createRateLimiter({ maxAttempts: 5, windowMs: 900_000 })
@@ -95,7 +95,7 @@ export function createAuthRoutes (
         'Content-Type': 'application/json; charset=utf-8',
         'Set-Cookie': cookie
       })
-      res.end(JSON.stringify({ user: { id: user.id, email: user.email, [displayField]: user[displayField] } }))
+      res.end(JSON.stringify({ user: { id: user.id, email: user.email, [displayField]: Reflect.get(user, displayField) as string | undefined ?? user.email } }))
     }
   })
 
@@ -136,7 +136,7 @@ export function createAuthRoutes (
       }
 
       const user = userResult.value
-      sendJson(res, { id: user.id, email: user.email, [displayField]: user[displayField] } as DocumentData)
+      sendJson(res, { id: user.id, email: user.email, [displayField]: Reflect.get(user, displayField) as string | undefined ?? user.email } as DocumentData)
     }
   })
 


### PR DESCRIPTION
## Summary

- **Bug**: `auth-routes.ts` hardcodes `SELECT ... name FROM users` in login, logout, and `/api/users/me` queries. Any app that renames the `name` column (e.g. to `username`) gets broken auth.
- **Fix**: Added `resolveDisplayField()` that finds the first `text` field on the auth collection that isn't `email` or `password_hash`, falling back to `email`. Uses `sanitizeIdentifier()` for safe SQL interpolation.
- **Tests**: 4 new unit tests for `resolveDisplayField()` covering username detection, email fallback, no-auth-collection fallback, and skipping email/password_hash fields.

## Test plan

- [x] All 544 CMS tests pass
- [x] All 157 monorepo tests pass
- [x] Lint clean
- [ ] Manual: verify login + `/me` with a collection using `username` instead of `name`
- [ ] Manual: verify fallback works when no extra text field exists