### PR TITLE
chore: upgrade @valencets/resultkit to 0.5 and adopt its strict eslint preset

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,39 +1,21 @@
 import neostandard, { plugins } from 'neostandard'
+import { opinionated as resultkitStrict } from '@valencets/resultkit/eslint'
 
 const tsPlugin = plugins['typescript-eslint'].plugin
 
 export default [
   { ignores: ['**/dist/', '**/public/js/', '**/storybook-static/'] },
   ...neostandard({ ts: true }),
+  // Railway-oriented error handling is enforced by resultkit's own preset.
+  // `opinionated` = strict Result rules (no throw/try/switch/enum/.catch/.finally/.unwrap)
+  // plus the named-exports rule this repo already requires.
+  ...resultkitStrict,
   {
     plugins: { '@typescript-eslint': tsPlugin },
     rules: {
       '@typescript-eslint/no-redeclare': 'off',
       complexity: ['error', 20],
-      '@typescript-eslint/no-explicit-any': 'error',
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'ThrowStatement',
-          message: 'Use Result/ResultAsync instead of throw'
-        },
-        {
-          selector: 'TryStatement',
-          message: 'Use Result/ResultAsync instead of try/catch'
-        },
-        {
-          selector: 'TSEnumDeclaration',
-          message: 'Use const unions instead of enum'
-        },
-        {
-          selector: 'SwitchStatement',
-          message: 'Use dictionary maps instead of switch'
-        },
-        {
-          selector: 'ExportDefaultDeclaration',
-          message: 'Use named exports instead of export default'
-        }
-      ]
+      '@typescript-eslint/no-explicit-any': 'error'
     }
   },
   // Tool config files require export default by convention
@@ -48,6 +30,7 @@ export default [
       '**/*.stories.ts',
       'lighthouserc.js',
       'tests/perf/**/*.js',
+      'tests/perf/**/*.mjs',
       'tests/e2e/server-start.mjs',
       '**/.storybook/**',
       'vitest.workspace.ts',

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@valencets/plugin-cloud-storage": "workspace:*",
     "@valencets/plugin-nested-docs": "workspace:*",
     "@valencets/plugin-seo": "workspace:*",
-    "@valencets/resultkit": "^0.2.0",
+    "@valencets/resultkit": "^0.5.0",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.22.0",
     "happy-dom": "^20.8.3",

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -34,7 +34,7 @@
     "@valencets/telemetry": "workspace:*",
     "@valencets/reactive": "workspace:*",
     "@valencets/ui": "workspace:*",
-    "@valencets/resultkit": "^0.2.0",
+    "@valencets/resultkit": "^0.5.0",
     "argon2": "^0.44.0",
     "sharp": "^0.34.5",
     "zod": "^4.3.6"

--- a/packages/cms/src/admin/editor/admin-client.ts
+++ b/packages/cms/src/admin/editor/admin-client.ts
@@ -1,3 +1,4 @@
+import { ResultAsync } from '@valencets/resultkit'
 import { themeManager, ThemeMode, createTokenSheet } from '@valencets/ui'
 import overrideCss from '../styles/km-overrides.css'
 import { initBlocksFields } from './blocks-client.js'
@@ -8,7 +9,7 @@ themeManager.setTheme(ThemeMode.Dark)
 themeManager.applyOverrides(createTokenSheet(overrideCss))
 
 // Lazy-load component registration — FOUC CSS hides :not(:defined) until upgrade
-import('@valencets/ui').then(({ registerAll }) => { registerAll() }).catch(() => { /* dynamic import failed */ })
+ResultAsync.fromPromise(import('@valencets/ui'), () => undefined).map(({ registerAll }) => registerAll())
 
 // Lazy-load Tiptap only when richtext editors exist on the page
 async function loadAndInitEditors (): Promise<void> {
@@ -18,14 +19,14 @@ async function loadAndInitEditors (): Promise<void> {
 
 // Script is type="module" so DOM is ready — no need for DOMContentLoaded
 if (document.querySelector('.richtext-editor')) {
-  loadAndInitEditors().catch(() => { /* dynamic import failed */ })
+  ResultAsync.fromPromise(loadAndInitEditors(), () => undefined)
 }
 initBlocksFields()
 
 // Login form reactive bindings — lazy-load to keep first-flight bundle small
 const loginForm = document.querySelector<HTMLFormElement>('form[action="/admin/login"]')
 if (loginForm) {
-  import('./login-reactive.js').then(({ initLoginForm }) => { initLoginForm(loginForm) }).catch(() => { /* dynamic import failed */ })
+  ResultAsync.fromPromise(import('./login-reactive.js'), () => undefined).map(({ initLoginForm }) => initLoginForm(loginForm))
 }
 
 // Wire up conditional field partial re-render (htmx-compatible data attributes)
@@ -41,27 +42,27 @@ if (conditionalForm) {
       for (const [key, val] of formData.entries()) {
         if (typeof val === 'string') params.append(key, val)
       }
-      return fetch(postUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: params.toString()
-      }).then((res) => {
+      const run = async (): Promise<void> => {
+        const res = await fetch(postUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString()
+        })
         if (res.ok && target) {
-          return res.text().then((html) => {
-            target.innerHTML = html // Server-rendered, escaped via escapeHtml()
-            if (target.querySelector('.richtext-editor')) {
-              return loadAndInitEditors()
-            }
-            return Promise.resolve()
-          })
+          const html = await res.text()
+          target.innerHTML = html // Server-rendered, escaped via escapeHtml()
+          if (target.querySelector('.richtext-editor')) {
+            await loadAndInitEditors()
+          }
         }
-        return Promise.resolve()
-      }).catch(() => { /* ignore fetch errors */ })
+      }
+      // Fetch failures are ignored — never rejects, so callers can fire-and-forget
+      return ResultAsync.fromPromise(run(), () => undefined).match(() => undefined, () => undefined)
     }
     conditionalForm.addEventListener('change', (e) => {
       const el = e.target as Element | null
       if (el?.closest('.condition-trigger')) {
-        handleConditionalChange().catch(() => { /* ignore */ })
+        handleConditionalChange()
       }
     })
   }
@@ -80,31 +81,34 @@ for (const wrap of mediaUploads) {
     if (!file) return
     const formData = new FormData()
     formData.append('file', file)
-    fetch(endpoint, { method: 'POST', body: formData })
-      .then((res) => res.json() as Promise<{ filename?: string; id?: string }>)
-      .then((json) => {
-        const value = json.id ?? json.filename ?? ''
-        hiddenInput.value = value
-        if (preview) {
-          if (file.type.startsWith('image/')) {
-            const img = document.createElement('img')
-            img.src = `/media/${encodeURIComponent(value)}`
-            img.alt = ''
-            preview.replaceChildren(img)
-          } else {
-            const span = document.createElement('span')
-            span.textContent = file.name
-            preview.replaceChildren(span)
-          }
+    const upload = async (): Promise<void> => {
+      const res = await fetch(endpoint, { method: 'POST', body: formData })
+      const json = await res.json() as { filename?: string; id?: string }
+      const value = json.id ?? json.filename ?? ''
+      hiddenInput.value = value
+      if (preview) {
+        if (file.type.startsWith('image/')) {
+          const img = document.createElement('img')
+          img.src = `/media/${encodeURIComponent(value)}`
+          img.alt = ''
+          preview.replaceChildren(img)
+        } else {
+          const span = document.createElement('span')
+          span.textContent = file.name
+          preview.replaceChildren(span)
         }
-      })
-      .catch(() => {
+      }
+    }
+    ResultAsync.fromPromise(upload(), () => undefined).match(
+      () => undefined,
+      () => {
         if (preview) {
           const span = document.createElement('span')
           span.style.color = 'var(--val-color-error)'
           span.textContent = 'Upload failed'
           preview.replaceChildren(span)
         }
-      })
+      }
+    )
   })
 }

--- a/packages/cms/src/admin/editor/admin-client.ts
+++ b/packages/cms/src/admin/editor/admin-client.ts
@@ -9,7 +9,7 @@ themeManager.setTheme(ThemeMode.Dark)
 themeManager.applyOverrides(createTokenSheet(overrideCss))
 
 // Lazy-load component registration — FOUC CSS hides :not(:defined) until upgrade
-ResultAsync.fromPromise(import('@valencets/ui'), () => undefined).map(({ registerAll }) => registerAll())
+ResultAsync.fromPromise(import('@valencets/ui').then(({ registerAll }) => registerAll()), () => undefined)
 
 // Lazy-load Tiptap only when richtext editors exist on the page
 async function loadAndInitEditors (): Promise<void> {
@@ -26,7 +26,7 @@ initBlocksFields()
 // Login form reactive bindings — lazy-load to keep first-flight bundle small
 const loginForm = document.querySelector<HTMLFormElement>('form[action="/admin/login"]')
 if (loginForm) {
-  ResultAsync.fromPromise(import('./login-reactive.js'), () => undefined).map(({ initLoginForm }) => initLoginForm(loginForm))
+  ResultAsync.fromPromise(import('./login-reactive.js').then(({ initLoginForm }) => initLoginForm(loginForm)), () => undefined)
 }
 
 // Wire up conditional field partial re-render (htmx-compatible data attributes)

--- a/packages/cms/src/scheduler.ts
+++ b/packages/cms/src/scheduler.ts
@@ -1,3 +1,4 @@
+import { ResultAsync } from '@valencets/resultkit'
 import type { DbPool } from '@valencets/db'
 import type { CollectionRegistry } from './schema/registry.js'
 import { isValidIdentifier } from './db/sql-sanitize.js'
@@ -15,10 +16,14 @@ export function startPublishScheduler (
     for (const col of collections.getAll()) {
       if (!col.versions?.drafts) continue
       if (!isValidIdentifier(col.slug)) continue
-      pool.sql.unsafe(
-        `UPDATE "${col.slug}" SET "_status" = 'published', "publish_at" = NULL, "updated_at" = NOW() WHERE "_status" = 'draft' AND "publish_at" IS NOT NULL AND "publish_at" <= NOW() AND "deleted_at" IS NULL`,
-        []
-      ).catch(() => { /* scheduled publish — error is non-fatal */ })
+      // Scheduled publish — failure is non-fatal, contained at the boundary
+      ResultAsync.fromPromise(
+        pool.sql.unsafe(
+          `UPDATE "${col.slug}" SET "_status" = 'published', "publish_at" = NULL, "updated_at" = NOW() WHERE "_status" = 'draft' AND "publish_at" IS NOT NULL AND "publish_at" <= NOW() AND "deleted_at" IS NULL`,
+          []
+        ),
+        () => undefined
+      )
     }
   }, intervalMs)
 

--- a/packages/cms/src/telemetry-scheduler.ts
+++ b/packages/cms/src/telemetry-scheduler.ts
@@ -1,3 +1,4 @@
+import { ResultAsync } from '@valencets/resultkit'
 import type { DbPool } from '@valencets/db'
 
 export interface TelemetrySchedulerHandle {
@@ -30,7 +31,7 @@ export function startTelemetryScheduler (
     const dateOnly = s.slice(0, 10)
 
     // Session summaries
-    pool.sql.unsafe(`
+    const summaryChain = pool.sql.unsafe(`
       INSERT INTO session_summaries (period_start, period_end, total_sessions, unique_referrers, device_mobile, device_desktop, device_tablet)
       SELECT $1::timestamptz, $2::timestamptz, COUNT(*)::int, COUNT(DISTINCT referrer)::int,
         COUNT(*) FILTER (WHERE device_type = 'mobile')::int,
@@ -72,7 +73,8 @@ export function startTelemetryScheduler (
             conversion_count = EXCLUDED.conversion_count, synced_at = NOW()
         `, [siteId, dateOnly, sessionCount, pageviewCount, conversionCount])
       })
-      .catch(() => { /* Aggregation failure is non-fatal — tables may not exist yet */ })
+    // Aggregation failure is non-fatal (tables may not exist yet) — contained at the boundary
+    ResultAsync.fromPromise(summaryChain, () => undefined)
   }
 
   // Run once immediately, then on interval

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@valencets/resultkit": "^0.2.0"
+    "@valencets/resultkit": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^25.4.0"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -22,7 +22,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@valencets/resultkit": "^0.2.0",
+    "@valencets/resultkit": "^0.5.0",
     "postgres": "^3.4.8",
     "zod": "^4.3.6"
   },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@valencets/cms": "workspace:*",
-    "@valencets/resultkit": "^0.2.0",
+    "@valencets/resultkit": "^0.5.0",
     "graphql": "^16.10.0"
   },
   "devDependencies": {

--- a/packages/plugin-cloud-storage/package.json
+++ b/packages/plugin-cloud-storage/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.782.0",
-    "@valencets/resultkit": "^0.2.0"
+    "@valencets/resultkit": "^0.5.0"
   },
   "devDependencies": {
     "@valencets/cms": "workspace:*",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@valencets/core": "workspace:*",
     "@valencets/db": "workspace:*",
-    "@valencets/resultkit": "^0.2.0",
+    "@valencets/resultkit": "^0.5.0",
     "postgres": "^3.4.8"
   },
   "devDependencies": {

--- a/packages/valence/package.json
+++ b/packages/valence/package.json
@@ -26,7 +26,7 @@
     "@valencets/core": "workspace:*",
     "@valencets/db": "workspace:*",
     "@valencets/telemetry": "workspace:*",
-    "@valencets/resultkit": "^0.2.0",
+    "@valencets/resultkit": "^0.5.0",
     "tsx": "^4.21.0",
     "zod": "^4.3.6"
   },

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -563,17 +563,20 @@ async function runDev (): Promise<void> {
         onConfigChange: () => {
           markConfigChanged(learnSignals!)
           // Reload config to get updated slug list + regenerate codegen
-          loadUserConfig().then(cfg => {
-            if (!cfg) return
-            currentConfigSlugs = cfg.collections.map(c => c.slug)
-            regenerateFromConfig(projectDir, cfg.collections).match(
-              (result) => {
-                const total = result.added.length + result.updated.length
-                if (total > 0) log(`Regenerated ${total} file(s). Skipped ${result.skipped.length} user-edited.`)
-              },
-              (e) => { log(`Regeneration error: ${e.message}`) }
-            )
-          }).catch((e) => { log('Config reload failed: ' + (e instanceof Error ? e.message : 'unknown')) })
+          ResultAsync.fromPromise(loadUserConfig(), (e) => e).match(
+            (cfg) => {
+              if (!cfg) return
+              currentConfigSlugs = cfg.collections.map(c => c.slug)
+              regenerateFromConfig(projectDir, cfg.collections).match(
+                (result) => {
+                  const total = result.added.length + result.updated.length
+                  if (total > 0) log(`Regenerated ${total} file(s). Skipped ${result.skipped.length} user-edited.`)
+                },
+                (e) => { log(`Regeneration error: ${e.message}`) }
+              )
+            },
+            (e) => { log('Config reload failed: ' + (e instanceof Error ? e.message : 'unknown')) }
+          )
         }
       })
     }
@@ -587,17 +590,20 @@ async function runDev (): Promise<void> {
     configWatcher = startConfigWatcher({
       configPath,
       onConfigChange: () => {
-        loadUserConfig().then(cfg => {
-          if (!cfg) return
-          currentConfigSlugs = cfg.collections.map(c => c.slug)
-          regenerateFromConfig(projectDir, cfg.collections).match(
-            (result) => {
-              const total = result.added.length + result.updated.length
-              if (total > 0) log(`Regenerated ${total} file(s). Skipped ${result.skipped.length} user-edited.`)
-            },
-            (e) => { log(`Regeneration error: ${e.message}`) }
-          )
-        }).catch((e) => { log('Config reload failed: ' + (e instanceof Error ? e.message : 'unknown')) })
+        ResultAsync.fromPromise(loadUserConfig(), (e) => e).match(
+          (cfg) => {
+            if (!cfg) return
+            currentConfigSlugs = cfg.collections.map(c => c.slug)
+            regenerateFromConfig(projectDir, cfg.collections).match(
+              (result) => {
+                const total = result.added.length + result.updated.length
+                if (total > 0) log(`Regenerated ${total} file(s). Skipped ${result.skipped.length} user-edited.`)
+              },
+              (e) => { log(`Regeneration error: ${e.message}`) }
+            )
+          },
+          (e) => { log('Config reload failed: ' + (e instanceof Error ? e.message : 'unknown')) }
+        )
       }
     })
   }

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -562,9 +562,11 @@ async function runDev (): Promise<void> {
         configPath,
         onConfigChange: () => {
           markConfigChanged(learnSignals!)
-          // Reload config to get updated slug list + regenerate codegen
-          ResultAsync.fromPromise(loadUserConfig(), (e) => e).match(
-            (cfg) => {
+          // Reload config to get updated slug list + regenerate codegen.
+          // Body runs inside the fromPromise boundary so a malformed config
+          // (throwing in the handler) is contained, not an unhandled rejection.
+          ResultAsync.fromPromise(
+            loadUserConfig().then((cfg) => {
               if (!cfg) return
               currentConfigSlugs = cfg.collections.map(c => c.slug)
               regenerateFromConfig(projectDir, cfg.collections).match(
@@ -574,9 +576,9 @@ async function runDev (): Promise<void> {
                 },
                 (e) => { log(`Regeneration error: ${e.message}`) }
               )
-            },
-            (e) => { log('Config reload failed: ' + (e instanceof Error ? e.message : 'unknown')) }
-          )
+            }),
+            (e) => e
+          ).match(() => undefined, (e) => { log('Config reload failed: ' + (e instanceof Error ? e.message : 'unknown')) })
         }
       })
     }
@@ -590,8 +592,10 @@ async function runDev (): Promise<void> {
     configWatcher = startConfigWatcher({
       configPath,
       onConfigChange: () => {
-        ResultAsync.fromPromise(loadUserConfig(), (e) => e).match(
-          (cfg) => {
+        // Body runs inside the fromPromise boundary so a malformed config
+        // (throwing in the handler) is contained, not an unhandled rejection.
+        ResultAsync.fromPromise(
+          loadUserConfig().then((cfg) => {
             if (!cfg) return
             currentConfigSlugs = cfg.collections.map(c => c.slug)
             regenerateFromConfig(projectDir, cfg.collections).match(
@@ -601,9 +605,9 @@ async function runDev (): Promise<void> {
               },
               (e) => { log(`Regeneration error: ${e.message}`) }
             )
-          },
-          (e) => { log('Config reload failed: ' + (e instanceof Error ? e.message : 'unknown')) }
-        )
+          }),
+          (e) => e
+        ).match(() => undefined, (e) => { log('Config reload failed: ' + (e instanceof Error ? e.message : 'unknown')) })
       }
     })
   }

--- a/packages/valence/src/dev-database.ts
+++ b/packages/valence/src/dev-database.ts
@@ -1,5 +1,5 @@
 import type { DbConfig, DbError, DbPool } from '@valencets/db'
-import type { ResultAsync } from '@valencets/resultkit'
+import { ResultAsync } from '@valencets/resultkit'
 import { log } from './cli-utils.js'
 
 interface PoolFactory {
@@ -23,9 +23,8 @@ export async function ensureDevDatabase (config: DbConfig, deps: PoolFactory): P
   log(`Ensuring dev database "${devDbName}" exists...`)
 
   const sqlStatement = `CREATE DATABASE "${devDbName}"`
-  await maintenancePool.sql.unsafe(sqlStatement).catch(() => {
-    /* database already exists — safe to ignore */
-  })
+  // Database already existing is the expected, safe-to-ignore failure
+  await ResultAsync.fromPromise(maintenancePool.sql.unsafe(sqlStatement), () => undefined)
 
   await deps.closePool(maintenancePool)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         specifier: workspace:*
         version: link:packages/plugin-seo
       '@valencets/resultkit':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.5.0
+        version: 0.5.0
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@25.4.0)(happy-dom@20.8.3)(lightningcss@1.32.0)(msw@2.12.13(@types/node@25.4.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2))
@@ -119,8 +119,8 @@ importers:
         specifier: workspace:*
         version: link:../reactive
       '@valencets/resultkit':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.5.0
+        version: 0.5.0
       '@valencets/telemetry':
         specifier: workspace:*
         version: link:../telemetry
@@ -153,8 +153,8 @@ importers:
   packages/core:
     dependencies:
       '@valencets/resultkit':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.5.0
+        version: 0.5.0
     devDependencies:
       '@types/node':
         specifier: ^25.4.0
@@ -163,8 +163,8 @@ importers:
   packages/db:
     dependencies:
       '@valencets/resultkit':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.5.0
+        version: 0.5.0
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
@@ -182,8 +182,8 @@ importers:
         specifier: workspace:*
         version: link:../cms
       '@valencets/resultkit':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.5.0
+        version: 0.5.0
       graphql:
         specifier: ^16.10.0
         version: 16.13.1
@@ -204,8 +204,8 @@ importers:
         specifier: ^3.782.0
         version: 3.1013.0
       '@valencets/resultkit':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.5.0
+        version: 0.5.0
     devDependencies:
       '@types/node':
         specifier: ^25.4.0
@@ -274,8 +274,8 @@ importers:
         specifier: workspace:*
         version: link:../db
       '@valencets/resultkit':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.5.0
+        version: 0.5.0
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
@@ -339,8 +339,8 @@ importers:
         specifier: workspace:*
         version: link:../db
       '@valencets/resultkit':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.5.0
+        version: 0.5.0
       '@valencets/telemetry':
         specifier: workspace:*
         version: link:../telemetry
@@ -2269,8 +2269,8 @@ packages:
     resolution: {integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@valencets/resultkit@0.2.0':
-    resolution: {integrity: sha512-CxyFQHriiwM0wpvsG+c9b1OwSFsS2qtBUS1PVr1tWcBHyJbgAC2J1/qA+AisSxDGbfLjcBUmjfrxb6oxGA3zZA==}
+  '@valencets/resultkit@0.5.0':
+    resolution: {integrity: sha512-zzTM6T1VjALEoQAmEKf+/yh93Yul10JIT5sJoehxZYtdmyRwmFCZQNc2Od/zVJBf21/70aiU74d8DTniGu7K/w==}
     engines: {node: '>=22'}
 
   '@vitest/coverage-v8@4.0.18':
@@ -5036,8 +5036,8 @@ packages:
   third-party-web@0.26.7:
     resolution: {integrity: sha512-buUzX4sXC4efFX6xg2bw6/eZsCUh8qQwSavC4D9HpONMFlRbcHhD8Je5qwYdCpViR6q0qla2wPP+t91a2vgolg==}
 
-  third-party-web@0.29.0:
-    resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -6850,7 +6850,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.53':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@phc/format@1.0.0': {}
 
@@ -7924,7 +7924,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       eslint-visitor-keys: 5.0.1
 
-  '@valencets/resultkit@0.2.0': {}
+  '@valencets/resultkit@0.5.0': {}
 
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.4.0)(happy-dom@20.8.3)(lightningcss@1.32.0)(msw@2.12.13(@types/node@25.4.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -11190,7 +11190,7 @@ snapshots:
 
   third-party-web@0.26.7: {}
 
-  third-party-web@0.29.0: {}
+  third-party-web@0.29.2: {}
 
   through@2.3.8: {}
 


### PR DESCRIPTION
## What & why

Phase 1 of the stores effort: get the workspace onto `@valencets/resultkit` 0.5 and adopt resultkit's canonical strict eslint preset. This unblocks rebasing the `feat/valence-stores` work onto a 0.5 baseline.

There is a separate `claude/valence-resultkit-0.5-0v3lev` branch that bumped resultkit, but it was a single version-bump commit cut from `master` (which has diverged from `development`). Rather than merge that stale branch, this re-applies the bump on top of `development` where the active work lives.

## Changes

- **`chore(deps)`** — bump `@valencets/resultkit` `^0.2.0` → `^0.5.0` across all 8 `package.json` files; lockfile regenerated via `pnpm install`. Typecheck confirms 0.5 is API-compatible for everything in use (`ok`/`err`/`okAsync`/`errAsync`/`ResultAsync`/`fromThrowable`/`fromPromise`) — 0.5 only adds exports and widens the error-callback param from `unknown` to `Caught` (contravariantly compatible).
- **`chore(eslint)`** — replace the hand-maintained `no-restricted-syntax` block with resultkit's `opinionated` preset (`@valencets/resultkit/eslint`). `opinionated` = the strict Result-oriented rules **plus** the `export default` ban this repo already enforced (the bare `strict` bundle would have dropped it). This adds new bans the repo didn't have: `.catch`, `.finally`, `.unwrap`, `.unwrapErr`.
- **`chore(cms)` / `chore(valence)`** — the preset flagged 11 production `.catch()` sites; all converted to the `ResultAsync.fromPromise(p, errFn)` boundary pattern, preserving the existing fire-and-forget / error-swallowing semantics exactly. Files: `cms/admin-client.ts` (6 browser sites), `cms/scheduler.ts`, `cms/telemetry-scheduler.ts`, `valence/cli.ts` (2), `valence/dev-database.ts`.
- One perf-test fixture (`tests/perf/server.mjs`) bootstrap was added to the existing test-infra eslint exemption list, alongside the `tests/perf/**/*.js` and `tests/e2e/server-start.mjs` entries already there (it had only missed `.mjs`).

Commits are `chore`-scoped: this is behaviour-preserving tooling/lint conformance, which doesn't fit the repo's `RED`→`GREEN` TDD pairing required for `fix`/`refactor`.

## Test plan

Green locally (everything runnable without Docker):

- `pnpm build` (typecheck, all 11 packages)
- `pnpm lint` + `pnpm check:patterns`
- `pnpm check:size` (admin-client bundle 2.6 KB gzip, budget 14 KB)
- `pnpm test:smoke` (full unit suite, all 11 packages)
- contract tests (41), CMS coverage gate (82.91% stmts > 75%), `pnpm api:check`
- `check:tdd-sequence`

Not runnable in this environment (no Docker/Postgres/browser): Integration, E2E, Visual jobs.

Note: the `Security Audit` job (`pnpm audit --audit-level=high`) fails on pre-existing advisories (esbuild, etc.) already on the codebase. resultkit 0.5 has zero dependencies, so this bump is audit-neutral.

https://claude.ai/code/session_01VDPG7XK7hEnaanNWzJfo42

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDPG7XK7hEnaanNWzJfo42)_