### PR TITLE
chore(ci): make the merge gate meaningful and stop spurious failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,29 +18,22 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# ---------------------------------------------------------------------------
+# Pipeline shape
+#
+#   Required gate (ci-gate) — deterministic correctness signals only:
+#     lint, build, unit, integration, e2e, contracts, api-review
+#
+#   Advisory (continue-on-error, never blocks a merge) — reported, triaged
+#   out of band: security audit, coverage, visual regression, tdd-history,
+#   lighthouse, performance, storybook, quarantine.
+#
+#   `build` compiles once and publishes packages/*/dist as a shared artifact;
+#   downstream jobs unpack it instead of rebuilding from scratch.
+# ---------------------------------------------------------------------------
+
 jobs:
-  tdd-history:
-    name: TDD History
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Validate TDD commit sequence
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1
-            BASE="$(git merge-base HEAD "origin/${{ github.base_ref }}")"
-            if [ "${{ github.base_ref }}" = "master" ] && [ "${{ github.head_ref }}" = "development" ]; then
-              TDD_SEQUENCE_START=f3aae193 bash scripts/check-tdd-commit-sequence.sh range "$BASE..HEAD"
-            else
-              bash scripts/check-tdd-commit-sequence.sh range "$BASE..HEAD"
-            fi
-          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            bash scripts/check-tdd-commit-sequence.sh range "${{ github.event.before }}..${{ github.sha }}"
-          elif git rev-parse HEAD^ >/dev/null 2>&1; then
-            bash scripts/check-tdd-commit-sequence.sh range "HEAD^..HEAD"
-          fi
+  # ---- Required correctness gate -----------------------------------------
 
   lint:
     name: Lint
@@ -51,31 +44,21 @@ jobs:
       - run: pnpm lint
       - run: pnpm check:patterns
 
-  typecheck:
-    name: Typecheck
+  build:
+    name: Build & Typecheck
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
       - run: pnpm build
       - run: pnpm check:size
-
-  security:
-    name: Security Audit
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-project
-      - run: pnpm audit --audit-level=high
-
-  build:
-    name: Build
-    needs: [lint, typecheck]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-project
-      - run: pnpm build
+      - name: Package build output
+        run: tar -czf build-dist.tar.gz packages/*/dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-dist
+          path: build-dist.tar.gz
+          retention-days: 1
 
   unit:
     name: Unit Tests
@@ -84,26 +67,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-      - run: pnpm build
-      - run: pnpm test
-
-  quarantine:
-    name: Quarantine
-    needs: [unit]
-    runs-on: ubuntu-24.04
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-project
-      - run: pnpm build
-      - run: pnpm test:quarantine
-        continue-on-error: true
-      - uses: actions/upload-artifact@v4
-        if: always()
+      - uses: actions/download-artifact@v4
         with:
-          name: quarantine-results
-          path: quarantine-report.json
-          retention-days: 30
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
+      - run: pnpm test
 
   integration:
     name: Integration
@@ -123,7 +91,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-      - run: pnpm build
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
       - run: npx vitest run tests/integration/
         env:
           PGHOST: localhost
@@ -155,7 +126,10 @@ jobs:
         with:
           install-playwright: 'true'
           playwright-browser: chromium
-      - run: pnpm build
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
       - run: pnpm test:e2e --grep-invert Visual --shard=${{ matrix.shard }}/2
         env:
           PGHOST: localhost
@@ -201,55 +175,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-      - run: pnpm build
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
       - run: pnpm exec vitest run --config vitest.contracts.config.ts
 
-  coverage:
-    name: Coverage (80% gate)
+  api-review:
+    name: API Review
     needs: [build]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-      - run: pnpm build
-      - run: cd packages/cms && npx vitest run --coverage --coverage.thresholds.statements=75
-      - uses: actions/upload-artifact@v4
+      - uses: actions/download-artifact@v4
         with:
-          name: coverage-report
-          path: packages/cms/coverage/
-          retention-days: 30
-
-  api-review:
-    name: API Review
-    needs: [typecheck]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-project
-      - run: pnpm build
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
       - run: pnpm api:check
 
   ci-gate:
     name: CI Gate
-    needs: [unit, integration, e2e, e2e-merge-report, contracts, coverage, security]
+    needs: [lint, build, unit, integration, e2e, e2e-merge-report, contracts, api-review]
     runs-on: ubuntu-24.04
     if: always()
     steps:
-      - name: Check all upstream results
+      - name: Check required correctness jobs
         env:
+          LINT: ${{ needs.lint.result }}
+          BUILD: ${{ needs.build.result }}
           UNIT: ${{ needs.unit.result }}
           INTEGRATION: ${{ needs.integration.result }}
           E2E: ${{ needs.e2e.result }}
           E2E_MERGE: ${{ needs.e2e-merge-report.result }}
           CONTRACTS: ${{ needs.contracts.result }}
-          COVERAGE: ${{ needs.coverage.result }}
-          SECURITY: ${{ needs.security.result }}
+          API_REVIEW: ${{ needs.api-review.result }}
         run: |
-          results=("$UNIT" "$INTEGRATION" "$E2E" "$E2E_MERGE" "$CONTRACTS" "$COVERAGE" "$SECURITY")
+          results=("$LINT" "$BUILD" "$UNIT" "$INTEGRATION" "$E2E" "$E2E_MERGE" "$CONTRACTS" "$API_REVIEW")
           failed=false
           for result in "${results[@]}"; do
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
-              echo "Job failed: $result"
+              echo "Required job failed: $result"
               failed=true
             fi
           done
@@ -259,10 +225,68 @@ jobs:
           fi
           echo "CI gate: PASSED"
 
-  visual:
-    name: Visual Regression
-    needs: [unit]
+  # ---- Advisory jobs (never block a merge) -------------------------------
+
+  tdd-history:
+    name: TDD History (advisory)
     runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate TDD commit sequence
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            BASE="$(git merge-base HEAD "origin/${{ github.base_ref }}")"
+            if [ "${{ github.base_ref }}" = "master" ] && [ "${{ github.head_ref }}" = "development" ]; then
+              TDD_SEQUENCE_START=f3aae193 bash scripts/check-tdd-commit-sequence.sh range "$BASE..HEAD"
+            else
+              bash scripts/check-tdd-commit-sequence.sh range "$BASE..HEAD"
+            fi
+          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            bash scripts/check-tdd-commit-sequence.sh range "${{ github.event.before }}..${{ github.sha }}"
+          elif git rev-parse HEAD^ >/dev/null 2>&1; then
+            bash scripts/check-tdd-commit-sequence.sh range "HEAD^..HEAD"
+          fi
+
+  security:
+    name: Security Audit (advisory)
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-project
+      # Production dependencies only. Dev-tooling CVEs (vitest, vite, lighthouse,
+      # stryker, …) are triaged by Dependabot rather than blocking merges.
+      - run: pnpm audit --prod --audit-level=high
+
+  coverage:
+    name: Coverage (advisory)
+    needs: [build]
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-project
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
+      - run: cd packages/cms && npx vitest run --coverage --coverage.thresholds.statements=75
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: packages/cms/coverage/
+          retention-days: 30
+
+  visual:
+    name: Visual Regression (advisory)
+    needs: [build]
+    runs-on: ubuntu-24.04
+    continue-on-error: true
     services:
       postgres:
         image: postgres:16
@@ -280,13 +304,15 @@ jobs:
         with:
           install-playwright: 'true'
           playwright-browser: chromium
-      - run: pnpm build
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
       - run: pnpm test:visual
         env:
           PGHOST: localhost
           PGPORT: 5432
           PGUSER: postgres
-
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -296,9 +322,30 @@ jobs:
             tests/e2e/__snapshots__/
           retention-days: 7
 
+  quarantine:
+    name: Quarantine (advisory)
+    needs: [build]
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-project
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
+      - run: pnpm test:quarantine
+        continue-on-error: true
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: quarantine-results
+          path: quarantine-report.json
+          retention-days: 30
+
   lighthouse:
-    name: Lighthouse
-    needs: [unit]
+    name: Lighthouse (advisory)
+    needs: [build]
     runs-on: ubuntu-24.04
     continue-on-error: true
     services:
@@ -315,7 +362,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-      - run: pnpm build
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
       - name: Start test server
         run: |
           nohup node --import tsx tests/e2e/server-start.mjs > /tmp/lhci-server.log 2>&1 &
@@ -363,8 +413,8 @@ jobs:
           retention-days: 30
 
   perf:
-    name: Performance (k6)
-    needs: [unit]
+    name: Performance (k6) (advisory)
+    needs: [build]
     runs-on: ubuntu-24.04
     continue-on-error: true
     services:
@@ -382,7 +432,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
       - uses: grafana/setup-k6-action@v1
-      - run: pnpm build
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
       - name: Start perf test server
         run: node tests/perf/server.mjs &
         env:
@@ -415,20 +468,25 @@ jobs:
           retention-days: 30
 
   storybook:
-    name: Storybook
-    needs: [unit]
+    name: Storybook (advisory)
+    needs: [build]
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
-      - run: pnpm build
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-dist
+      - run: tar -xzf build-dist.tar.gz
       - run: cd packages/ui && pnpm storybook:build
       - uses: actions/upload-artifact@v4
         with:
           name: storybook-static
           path: packages/ui/storybook-static/
           retention-days: 30
+
+  # ---- master-only release pipeline --------------------------------------
 
   e2e-full:
     name: E2E Full (${{ matrix.browser }}, ${{ matrix.shard }}/4)
@@ -550,6 +608,8 @@ jobs:
             gh release create "$TAG" --title "$NAME v$VERSION" --notes "$(printf '## %s v%s\n\n### Changes\n\n%s\n\n### Install\n\n```bash\npnpm add %s@%s\n```' "$NAME" "$VERSION" "$CHANGELOG" "$NAME" "$VERSION")"
             echo "Created release $TAG"
           done
+
+  # ---- scheduled / weekly jobs -------------------------------------------
 
   stryker-full:
     name: Stryker (full, weekly)

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "overrides": {
       "flatted": ">=3.4.2",
       "fast-xml-parser": ">=5.5.7",
+      "fast-xml-builder": ">=1.1.7",
+      "linkify-it": ">=5.0.1",
       "picomatch": ">=4.0.4"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   flatted: '>=3.4.2'
   fast-xml-parser: '>=5.5.7'
+  fast-xml-builder: '>=1.1.7'
+  linkify-it: '>=5.0.1'
   picomatch: '>=4.0.4'
 
 importers:
@@ -3242,8 +3244,8 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
@@ -3925,8 +3927,8 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
@@ -4372,6 +4374,10 @@ packages:
 
   path-expression-matcher@1.2.0:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
+    engines: {node: '>=14.0.0'}
+
+  path-expression-matcher@1.6.1:
+    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
@@ -5512,6 +5518,10 @@ packages:
   xdg-basedir@4.0.0:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -9098,13 +9108,14 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.2.0:
     dependencies:
-      path-expression-matcher: 1.2.0
+      path-expression-matcher: 1.6.1
+      xml-naming: 0.1.0
 
   fast-xml-parser@5.5.8:
     dependencies:
-      fast-xml-builder: 1.1.4
+      fast-xml-builder: 1.2.0
       path-expression-matcher: 1.2.0
       strnum: 2.2.1
 
@@ -9806,7 +9817,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -9926,7 +9937,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -10251,6 +10262,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.2.0: {}
+
+  path-expression-matcher@1.6.1: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -11593,6 +11606,8 @@ snapshots:
       is-wsl: 3.1.1
 
   xdg-basedir@4.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   y18n@4.0.3: {}
 


### PR DESCRIPTION
## Why

The pipeline was failing for reasons unrelated to code correctness, and blocking every merge while doing it. Root cause analysis:

- **The `Security Audit` job (`pnpm audit --audit-level=high`) was wired into the required `CI Gate`.** It fails on *any* new advisory anywhere in the tree, so the pipeline goes red with zero code change. Evidence: 53 advisories total, but `pnpm audit --prod` reports only 4 — and ~49 are dev tooling (vitest, vite, lighthouse/`@lhci/cli`, stryker, testcontainers, happy-dom) that never ship to users. Gating merges on that feed is the definition of brittle.
- **The gate couldn't distinguish "our code broke" from "a new CVE dropped"** — both failed `CI Gate` identically.
- **Visual Regression was blocking and host-rendered** (`pnpm test:visual`, not the containerized path), despite CONTRIBUTING.md calling visual "too environment-sensitive." Pixel/font drift reddened the run.
- **~13 jobs each ran `pnpm build` from scratch** — no artifact sharing, so every run was slow and every flake cost a long feedback loop.
- **TDD-History failed CI on commit-message shape**, not code.

## What changed

**A meaningful required gate.** `CI Gate` now requires only deterministic correctness signals:
`lint`, `build` (+ typecheck + bundle-size), `unit`, `integration`, `e2e`, `e2e-merge-report`, `contracts`, `api-review`.

**Everything advisory is `continue-on-error` and out of the gate** (reported, never blocks a merge): `security`, `coverage`, `visual`, `tdd-history`, plus the already-advisory `lighthouse`, `perf`, `storybook`, `quarantine`.

**Security audit is prod-only.** `pnpm audit --prod --audit-level=high`, non-blocking — Dependabot (already enabled) triages dev-dependency CVEs.

**Build once, reuse everywhere.** A single `build` job compiles and publishes `packages/*/dist` as a `build-dist` artifact; 11 downstream jobs unpack it instead of rebuilding. (Master-only release jobs still build their own, intentionally.) Verified the tar round-trip preserves all 12 packages' dist including the cms client bundle.

`typecheck` is folded into `Build & Typecheck`.

## ⚠️ Required follow-up (branch protection)

This renames jobs and removes `security`/`coverage` from the gate. **Branch-protection required-check lists for `development` and `master` must be updated** to match — ideally require only **`CI Gate`** (optionally `Lint`). Otherwise PRs may hang waiting on now-removed/renamed checks. This is a GitHub Settings change, not something the workflow file can do.

## Validation

- `ci.yml` parses (yaml.safe_load); all `needs:` references resolve across the 25 jobs.
- Gate membership and advisory split confirmed programmatically.
- Build-artifact tar/extract round-trip verified locally (12 dist dirs, cms `dist/client/*` present).

https://claude.ai/code/session_01VDPG7XK7hEnaanNWzJfo42

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDPG7XK7hEnaanNWzJfo42)_