### PR TITLE
feat(store): client runtime delivery, store codegen wiring, persist option

### DIFF
--- a/docs/STORES.md
+++ b/docs/STORES.md
@@ -87,6 +87,25 @@ is identical across scopes.
 Session-scoped state never crosses sessions — neither via `getState` nor
 via SSE.
 
+### Durable state with `persist`
+
+Persistence is orthogonal to audience. `user` scope always persists;
+`session` and `global` stores opt in with `persist: true`:
+
+```ts
+{ slug: 'server-config', scope: 'session', persist: true, fields: [...] }
+```
+
+A persisted session store writes each bucket to `store_states` keyed by
+the signed session id, so anonymous state survives server restarts and
+LRU pressure — the durable-anonymous-draft case (config generators,
+carts) that in-memory session state cannot cover. A persisted global
+store keys one row as `__global__` and survives restarts too.
+`persist: true` on `page` scope is a definition error: page stores have
+no server state to persist. Anonymous rows are never expired
+automatically — prune `store_states` by `updated_at` on whatever
+schedule fits the app.
+
 ## The mutation lifecycle
 
 ```
@@ -157,8 +176,34 @@ events into DOM swaps, and delegates `[data-mutation]` clicks.
 Keep store definitions importable by both `valence.config.ts` and client
 entry code. Only client-safe parts (fields, input schemas, `client` fns,
 `derived`, `fragment`) are read in the browser; `server` fns execute only
-server-side. Generated typed modules (`createXStore` factories plus state
-and input interfaces) come from the store codegen.
+server-side. Typed modules (`createXStore` factories plus state and input
+interfaces) are regenerated into `src/shared/stores/<slug>.ts` whenever
+`valence.config.ts` changes — user-edited files (missing the
+`// @generated` marker) are never overwritten.
+
+## Client delivery
+
+The framework ships the runtime — no bundler configuration in the app.
+Put the client bootstrap at the conventional entry `src/app/client.ts`
+(or `.js`):
+
+```ts
+// src/app/client.ts
+import { initStores } from '@valencets/store/client'
+import { serverConfigDefinition } from '../shared/stores/definitions.js'
+
+initStores([serverConfigDefinition])
+```
+
+`valence dev` bundles it with esbuild (rebuilt on change, inline source
+maps), `valence start` bundles once at boot (minified), and both serve
+the result at `/_valence/client.js` with ETag revalidation. Every
+server-rendered page that references a store via `data-store` gets
+`<script type="module" src="/_valence/client.js"></script>` injected
+automatically alongside its hydration tags; pages without store
+references stay byte-identical. A compile error never takes the server
+down — the route answers 503 (dev logs the error and recovers on the
+next file change) and the last good bundle keeps serving.
 
 ## Server endpoints
 

--- a/packages/store/src/__tests__/store-codegen.test.ts
+++ b/packages/store/src/__tests__/store-codegen.test.ts
@@ -138,3 +138,10 @@ describe('generateStoreModule', () => {
     expect(code).toContain('export')
   })
 })
+
+describe('codegen barrel export', () => {
+  it('exports generateStoreModule from the package root for build-time consumers', async () => {
+    const barrel = await import('../index.js')
+    expect(typeof (barrel as { generateStoreModule?: unknown }).generateStoreModule).toBe('function')
+  })
+})

--- a/packages/store/src/__tests__/store-definition.test.ts
+++ b/packages/store/src/__tests__/store-definition.test.ts
@@ -238,3 +238,72 @@ describe('store', () => {
     expect(result.isOk()).toBe(true)
   })
 })
+
+describe('persist option', () => {
+  it('accepts persist: true on session scope and carries it into the definition', () => {
+    const result = store({
+      slug: 'draft',
+      scope: 'session',
+      persist: true,
+      fields: [field.text({ name: 'body' })],
+      mutations: {}
+    })
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value.persist).toBe(true)
+    }
+  })
+
+  it('accepts persist: true on global scope', () => {
+    const result = store({
+      slug: 'banner',
+      scope: 'global',
+      persist: true,
+      fields: [field.text({ name: 'message' })],
+      mutations: {}
+    })
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value.persist).toBe(true)
+    }
+  })
+
+  it('accepts persist: true on user scope (already implied)', () => {
+    const result = store({
+      slug: 'prefs',
+      scope: 'user',
+      persist: true,
+      fields: [field.boolean({ name: 'dark' })],
+      mutations: {}
+    })
+    expect(result.isOk()).toBe(true)
+  })
+
+  it('rejects persist: true on page scope — page stores have no server state to persist', () => {
+    const result = store({
+      slug: 'wizard',
+      scope: 'page',
+      persist: true,
+      fields: [field.number({ name: 'step', default: 0 })],
+      mutations: {}
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.code).toBe(StoreErrorCode.INVALID_PERSIST)
+      expect(result.error.message).toContain('page')
+    }
+  })
+
+  it('leaves persist undefined when not declared', () => {
+    const result = store({
+      slug: 'cart',
+      scope: 'session',
+      fields: [field.number({ name: 'count', default: 0 })],
+      mutations: {}
+    })
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value.persist).toBeUndefined()
+    }
+  })
+})

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -14,6 +14,13 @@ export function store (input: StoreInput): Result<StoreDefinition, StoreError> {
     })
   }
 
+  if (input.persist === true && input.scope === 'page') {
+    return err({
+      code: StoreErrorCode.INVALID_PERSIST,
+      message: 'persist: true is invalid for page scope — page stores are client-only and have no server state to persist'
+    })
+  }
+
   if (input.fields.length === 0) {
     return err({
       code: StoreErrorCode.INVALID_FIELDS,
@@ -44,6 +51,7 @@ export function store (input: StoreInput): Result<StoreDefinition, StoreError> {
   const definition: StoreDefinition = {
     slug: input.slug,
     scope: input.scope,
+    ...(input.persist !== undefined ? { persist: input.persist } : {}),
     fields: input.fields,
     mutations: input.mutations,
     ...(input.fragment ? { fragment: input.fragment } : {}),
@@ -87,3 +95,4 @@ export type {
   DerivedFn
 } from './types.js'
 export { escapeHtml } from './escape.js'
+export { generateStoreModule } from './codegen/store-generator.js'

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -12,6 +12,7 @@ export type StoreScope = typeof StoreScope[keyof typeof StoreScope]
 export const StoreErrorCode = Object.freeze({
   INVALID_SLUG: 'INVALID_SLUG',
   INVALID_FIELDS: 'INVALID_FIELDS',
+  INVALID_PERSIST: 'INVALID_PERSIST',
   DUPLICATE_FIELD: 'DUPLICATE_FIELD',
   INVALID_MUTATION: 'INVALID_MUTATION',
   MUTATION_FAILED: 'MUTATION_FAILED',
@@ -83,6 +84,9 @@ export type DerivedFn = (state: StoreState) => StoreValue
 export interface StoreDefinition {
   readonly slug: string
   readonly scope: StoreScope
+  /** Durable state: back this store with postgres instead of process memory.
+   *  Implied for `user` scope; opt-in for `session` and `global`. */
+  readonly persist?: boolean
   readonly fields: readonly StoreFieldConfig[]
   readonly mutations: Readonly<Record<string, MutationDefinition>>
   readonly fragment?: FragmentRenderFn
@@ -92,6 +96,7 @@ export interface StoreDefinition {
 export interface StoreInput {
   readonly slug: string
   readonly scope: StoreScope
+  readonly persist?: boolean
   readonly fields: readonly StoreFieldConfig[]
   readonly mutations: Record<string, {
     readonly input: readonly StoreFieldConfig[]

--- a/packages/valence/package.json
+++ b/packages/valence/package.json
@@ -28,6 +28,7 @@
     "@valencets/resultkit": "^0.5.0",
     "@valencets/store": "workspace:*",
     "@valencets/telemetry": "workspace:*",
+    "esbuild": "^0.27.0",
     "tsx": "^4.21.0",
     "zod": "^4.3.6"
   },

--- a/packages/valence/src/__tests__/client-bundler.test.ts
+++ b/packages/valence/src/__tests__/client-bundler.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import {
+  resolveClientEntry,
+  createClientBundler,
+  registerClientBundleRoute,
+  CLIENT_BUNDLE_PATH
+} from '../client-bundler.js'
+import type { ClientBundler } from '../client-bundler.js'
+import type { RouteHandler } from '../define-config.js'
+
+interface CapturedResponse {
+  statusCode: number
+  headers: { [key: string]: string }
+  body: string
+}
+
+function mockRes (): ServerResponse & { _captured: CapturedResponse } {
+  const captured: CapturedResponse = { statusCode: 0, headers: {}, body: '' }
+  const res = Object.assign(new EventEmitter(), {
+    _captured: captured,
+    writeHead (status: number, headers?: { [key: string]: string }) {
+      captured.statusCode = status
+      if (headers) Object.assign(captured.headers, headers)
+      return res
+    },
+    setHeader (name: string, value: string) { captured.headers[name] = value },
+    end (body?: string) { if (body) captured.body = body }
+  })
+  return res as unknown as ServerResponse & { _captured: CapturedResponse }
+}
+
+function mockReq (headers?: { [key: string]: string }): IncomingMessage {
+  return Object.assign(new EventEmitter(), { headers: headers ?? {}, method: 'GET' }) as unknown as IncomingMessage
+}
+
+function makeProject (entrySource?: string, helperSource?: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'valence-bundler-'))
+  if (entrySource !== undefined) {
+    mkdirSync(join(dir, 'src', 'app'), { recursive: true })
+    writeFileSync(join(dir, 'src', 'app', 'client.ts'), entrySource)
+    if (helperSource !== undefined) {
+      writeFileSync(join(dir, 'src', 'app', 'greeting.ts'), helperSource)
+    }
+  }
+  return dir
+}
+
+const cleanups: Array<() => Promise<void> | void> = []
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()!()
+  }
+})
+
+function track (dir: string, bundler?: ClientBundler | null): void {
+  if (bundler) cleanups.push(() => bundler.dispose())
+  cleanups.push(() => { rmSync(dir, { recursive: true, force: true }) })
+}
+
+async function makeBundler (dir: string, watch: boolean): Promise<ClientBundler | null> {
+  const result = await createClientBundler({ projectDir: dir, watch })
+  const bundler = result.match(
+    (value) => value,
+    () => null
+  )
+  track(dir, bundler)
+  return bundler
+}
+
+describe('resolveClientEntry', () => {
+  it('finds the conventional src/app/client.ts entry', () => {
+    const dir = makeProject('export {}')
+    track(dir)
+    expect(resolveClientEntry(dir)).toBe(join(dir, 'src', 'app', 'client.ts'))
+  })
+
+  it('returns null when no client entry exists', () => {
+    const dir = makeProject()
+    track(dir)
+    expect(resolveClientEntry(dir)).toBeNull()
+  })
+})
+
+describe('createClientBundler', () => {
+  it('bundles a TypeScript entry and its imports into one browser ESM bundle', async () => {
+    const dir = makeProject(
+      "import { greeting } from './greeting.js'\nconst el: HTMLElement | null = document.querySelector('#app')\nif (el) el.textContent = greeting('valence')\n",
+      "export function greeting (name: string): string { return 'hello ' + name }\n"
+    )
+    const bundler = await makeBundler(dir, false)
+    expect(bundler).not.toBeNull()
+
+    const bundle = bundler!.getBundle()
+    expect(bundle).not.toBeNull()
+    expect(bundle!.js).toContain('hello ')
+    // TypeScript annotations are compiled away, not shipped
+    expect(bundle!.js).not.toContain('HTMLElement | null')
+    expect(bundle!.etag.length).toBeGreaterThan(8)
+  })
+
+  it('yields a null bundle and reports the error when the entry does not compile', async () => {
+    const dir = makeProject('const oops: number = {{{\n')
+    const logged: string[] = []
+    const result = await createClientBundler({ projectDir: dir, watch: false, log: (msg) => { logged.push(msg) } })
+    const bundler = result.match((value) => value, () => null)
+    track(dir, bundler)
+
+    expect(bundler).not.toBeNull()
+    expect(bundler!.getBundle()).toBeNull()
+    expect(logged.some(msg => msg.includes('client bundle'))).toBe(true)
+  })
+
+  it('rebuilds when the entry changes in watch mode', async () => {
+    const dir = makeProject('console.log("version-one")\n')
+    const bundler = await makeBundler(dir, true)
+    expect(bundler!.getBundle()!.js).toContain('version-one')
+
+    writeFileSync(join(dir, 'src', 'app', 'client.ts'), 'console.log("version-two")\n')
+
+    let js = ''
+    for (let attempt = 0; attempt < 100; attempt++) {
+      js = bundler!.getBundle()?.js ?? ''
+      if (js.includes('version-two')) break
+      await new Promise(resolve => setTimeout(resolve, 50))
+    }
+    expect(js).toContain('version-two')
+  })
+})
+
+describe('registerClientBundleRoute', () => {
+  async function serve (bundler: ClientBundler, headers?: { [key: string]: string }): Promise<CapturedResponse> {
+    const routes = new Map<string, RouteHandler>()
+    registerClientBundleRoute((method, path, handler) => { routes.set(`${method} ${path}`, handler) }, bundler)
+    const handler = routes.get(`GET ${CLIENT_BUNDLE_PATH}`)!
+    const res = mockRes()
+    await handler(mockReq(headers), res, {})
+    return res._captured
+  }
+
+  it('serves the bundle as JavaScript with an ETag', async () => {
+    const dir = makeProject('console.log("served")\n')
+    const bundler = await makeBundler(dir, false)
+
+    const captured = await serve(bundler!)
+    expect(captured.statusCode).toBe(200)
+    expect(captured.headers['Content-Type']).toContain('javascript')
+    expect(captured.headers['ETag']).toBeDefined()
+    expect(captured.body).toContain('served')
+  })
+
+  it('answers 304 when the client already holds the current bundle', async () => {
+    const dir = makeProject('console.log("cached")\n')
+    const bundler = await makeBundler(dir, false)
+
+    const first = await serve(bundler!)
+    const second = await serve(bundler!, { 'if-none-match': first.headers['ETag']! })
+    expect(second.statusCode).toBe(304)
+    expect(second.body).toBe('')
+  })
+
+  it('answers 503 while no bundle is available', async () => {
+    const dir = makeProject('const broken: string = {{{\n')
+    const bundler = await makeBundler(dir, false)
+
+    const captured = await serve(bundler!)
+    expect(captured.statusCode).toBe(503)
+  })
+})

--- a/packages/valence/src/__tests__/regenerate.test.ts
+++ b/packages/valence/src/__tests__/regenerate.test.ts
@@ -109,6 +109,10 @@ describe('regenerateFromConfig', () => {
 })
 
 describe('store module regeneration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('writes a generated typed module per store under src/shared/stores', async () => {
     const stores = [{
       slug: 'cart',

--- a/packages/valence/src/__tests__/regenerate.test.ts
+++ b/packages/valence/src/__tests__/regenerate.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { regenerateFromConfig } from '../codegen/regenerate.js'
 import { collection, field } from '@valencets/cms'
+import { field as storeField } from '@valencets/store'
+import { join } from 'node:path'
 
 vi.mock('node:fs/promises', () => ({
   writeFile: vi.fn(async () => {}),
@@ -103,5 +105,67 @@ describe('regenerateFromConfig', () => {
       c => String(c[0]).includes('entities/users')
     )
     expect(userEntityWrite).toBeUndefined()
+  })
+})
+
+describe('store module regeneration', () => {
+  it('writes a generated typed module per store under src/shared/stores', async () => {
+    const stores = [{
+      slug: 'cart',
+      scope: 'session' as const,
+      fields: [storeField.number({ name: 'count', default: 0 })],
+      mutations: {
+        increment: {
+          input: [storeField.number({ name: 'amount' })],
+          server: async () => {}
+        }
+      }
+    }]
+
+    const result = await regenerateFromConfig('/tmp/project', [], stores)
+    expect(result.isOk()).toBe(true)
+
+    const storeWrite = mockedWriteFile.mock.calls.find(
+      c => String(c[0]).includes(join('shared', 'stores', 'cart.ts'))
+    )
+    expect(storeWrite).toBeDefined()
+    const content = String(storeWrite![1])
+    expect(content.startsWith('// @generated')).toBe(true)
+    expect(content).toContain('createCartStore')
+    expect(content).toContain('CartState')
+  })
+
+  it('skips invalid store definitions without failing the run', async () => {
+    const stores = [{
+      slug: 'Bad Slug',
+      scope: 'session' as const,
+      fields: [storeField.number({ name: 'count', default: 0 })],
+      mutations: {}
+    }]
+
+    const result = await regenerateFromConfig('/tmp/project', [], stores)
+    expect(result.isOk()).toBe(true)
+
+    const storeWrite = mockedWriteFile.mock.calls.find(
+      c => String(c[0]).includes(join('shared', 'stores'))
+    )
+    expect(storeWrite).toBeUndefined()
+  })
+
+  it('generates nothing store-related when stores are omitted', async () => {
+    const collections = [
+      collection({
+        slug: 'posts',
+        fields: [field.text({ name: 'title', required: true })]
+      })
+    ]
+
+    const result = await regenerateFromConfig('/tmp/project', collections)
+    expect(result.isOk()).toBe(true)
+
+    const storeWrite = mockedWriteFile.mock.calls.find(
+      c => String(c[0]).includes(join('shared', 'stores'))
+    )
+    expect(storeWrite).toBeUndefined()
   })
 })

--- a/packages/valence/src/__tests__/store-wiring.test.ts
+++ b/packages/valence/src/__tests__/store-wiring.test.ts
@@ -425,3 +425,88 @@ describe('hydration auto-injection', () => {
     expect(out).toContain('"count":9')
   })
 })
+
+describe('persist option wiring', () => {
+  const SECRET = 'wiring-test-secret'
+
+  function persistPool (): { query: ReturnType<typeof vi.fn>; rows: Map<string, { [key: string]: unknown }> } {
+    const rows = new Map<string, { [key: string]: unknown }>()
+    const query = vi.fn(async (sql: string, ...params: string[]) => {
+      if (sql.startsWith('CREATE TABLE')) return []
+      if (sql.startsWith('INSERT')) {
+        rows.set(`${params[0]}|${params[1]}`, JSON.parse(params[2]!) as { [key: string]: unknown })
+        return []
+      }
+      const row = rows.get(`${params[0]}|${params[1]}`)
+      return row ? [{ state: row }] : []
+    })
+    return { query, rows }
+  }
+
+  it('session-scoped persist stores write through to store_states keyed by the signed session id', async () => {
+    const { mintSignedSessionId } = await import('../store-session.js')
+    const token = mintSignedSessionId(SECRET)
+    const sessionId = token.slice(0, token.indexOf('.'))
+
+    const { query, rows } = persistPool()
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore({ scope: 'session', persist: true })], registerRoute, {
+      secret: SECRET,
+      pool: { query }
+    })
+
+    const captured = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":4}}', `session_id=${token}`)
+    expect(captured.statusCode).toBe(200)
+    expect(JSON.parse(captured.body).state.count).toBe(4)
+
+    const sqlCalls = query.mock.calls.map(call => String(call[0]))
+    expect(sqlCalls.some(sql => sql.startsWith('CREATE TABLE IF NOT EXISTS'))).toBe(true)
+    expect(sqlCalls.some(sql => sql.includes('INSERT INTO store_states'))).toBe(true)
+    expect(rows.has(`counter|${sessionId}`)).toBe(true)
+  })
+
+  it('global persist stores share the __global__ state key', async () => {
+    const { mintSignedSessionId } = await import('../store-session.js')
+    const token = mintSignedSessionId(SECRET)
+
+    const { query, rows } = persistPool()
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore({ scope: 'global', persist: true })], registerRoute, {
+      secret: SECRET,
+      pool: { query }
+    })
+
+    await postMutation(routes, 'counter', 'increment', '{"args":{"amount":2}}', `session_id=${token}`)
+
+    expect(rows.has('counter|__global__')).toBe(true)
+  })
+
+  it('persisted state survives across sessions of the same signed id', async () => {
+    const { mintSignedSessionId } = await import('../store-session.js')
+    const token = mintSignedSessionId(SECRET)
+
+    const { query } = persistPool()
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore({ scope: 'session', persist: true })], registerRoute, {
+      secret: SECRET,
+      pool: { query }
+    })
+
+    await postMutation(routes, 'counter', 'increment', '{"args":{"amount":3}}', `session_id=${token}`)
+    const second = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":5}}', `session_id=${token}`)
+
+    expect(JSON.parse(second.body).state.count).toBe(8)
+  })
+
+  it('persist without a pool falls back to in-memory state', async () => {
+    const { mintSignedSessionId } = await import('../store-session.js')
+    const token = mintSignedSessionId(SECRET)
+
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore({ scope: 'session', persist: true })], registerRoute, { secret: SECRET })
+
+    const captured = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":7}}', `session_id=${token}`)
+    expect(captured.statusCode).toBe(200)
+    expect(JSON.parse(captured.body).state.count).toBe(7)
+  })
+})

--- a/packages/valence/src/__tests__/store-wiring.test.ts
+++ b/packages/valence/src/__tests__/store-wiring.test.ts
@@ -510,3 +510,49 @@ describe('persist option wiring', () => {
     expect(JSON.parse(captured.body).state.count).toBe(7)
   })
 })
+
+describe('client script auto-injection', () => {
+  const SECRET = 'wiring-test-secret'
+
+  function pageReq (cookie: string): IncomingMessage {
+    const emitter = new EventEmitter()
+    return Object.assign(emitter, { headers: { cookie }, method: 'GET' }) as unknown as IncomingMessage
+  }
+
+  it('injects one module script tag on store-referencing pages when a client bundle is configured', async () => {
+    const { registerRoute } = collectRoutes()
+    const hydrator = registerStoreRoutesOnServer([counterStore()], registerRoute, {
+      secret: SECRET,
+      clientScriptUrl: '/_valence/client.js'
+    })
+
+    const html = '<html><body><div data-store="counter"></div><div data-store="counter"></div></body></html>'
+    const out = await hydrator!(pageReq(''), mockRes(), html)
+
+    const tag = '<script type="module" src="/_valence/client.js"></script>'
+    expect(out).toContain(tag)
+    expect(out.indexOf(tag)).toBe(out.lastIndexOf(tag))
+    expect(out.indexOf(tag)).toBeLessThan(out.indexOf('</body>'))
+  })
+
+  it('leaves pages without store references untouched', async () => {
+    const { registerRoute } = collectRoutes()
+    const hydrator = registerStoreRoutesOnServer([counterStore()], registerRoute, {
+      secret: SECRET,
+      clientScriptUrl: '/_valence/client.js'
+    })
+
+    const html = '<html><body><p>plain page</p></body></html>'
+    const out = await hydrator!(pageReq(''), mockRes(), html)
+    expect(out).toBe(html)
+  })
+
+  it('injects no script tag when no client bundle is configured', async () => {
+    const { registerRoute } = collectRoutes()
+    const hydrator = registerStoreRoutesOnServer([counterStore()], registerRoute, { secret: SECRET })
+
+    const html = '<html><body><div data-store="counter"></div></body></html>'
+    const out = await hydrator!(pageReq(''), mockRes(), html)
+    expect(out).not.toContain('<script type="module"')
+  })
+})

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -580,7 +580,7 @@ async function runDev (): Promise<void> {
             loadUserConfig().then((cfg) => {
               if (!cfg) return
               currentConfigSlugs = cfg.collections.map(c => c.slug)
-              regenerateFromConfig(projectDir, cfg.collections).match(
+              regenerateFromConfig(projectDir, cfg.collections, cfg.stores).match(
                 (result) => {
                   const total = result.added.length + result.updated.length
                   if (total > 0) log(`Regenerated ${total} file(s). Skipped ${result.skipped.length} user-edited.`)
@@ -609,7 +609,7 @@ async function runDev (): Promise<void> {
           loadUserConfig().then((cfg) => {
             if (!cfg) return
             currentConfigSlugs = cfg.collections.map(c => c.slug)
-            regenerateFromConfig(projectDir, cfg.collections).match(
+            regenerateFromConfig(projectDir, cfg.collections, cfg.stores).match(
               (result) => {
                 const total = result.added.length + result.updated.length
                 if (total > 0) log(`Regenerated ${total} file(s). Skipped ${result.skipped.length} user-edited.`)

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -791,9 +791,12 @@ async function runDev (): Promise<void> {
     await loadedConfig.onServer({ server, pool, cms, registerRoute })
   }
 
+  // Bundle and serve the client entry (no-op if the project ships none)
+  const clientBundleUrl = await setupClientBundle(projectDir, registerRoute, true, log)
+
   // Register store routes (no-op if no stores defined)
   const { maybeRegisterStores } = await import('./store-wiring.js')
-  const storeHydrator = maybeRegisterStores(loadedConfig.stores, registerRoute, log, pool, devCmsSecret)
+  const storeHydrator = maybeRegisterStores(loadedConfig.stores, registerRoute, log, pool, devCmsSecret, clientBundleUrl)
 
   // Schema-driven generated route map (custom routes take priority)
   const generatedRoutes = generateCollectionRoutes(userConfig, loadedConfig.routes)
@@ -828,6 +831,28 @@ async function runDev (): Promise<void> {
 }
 
 // -- start --
+
+async function setupClientBundle (
+  projectDir: string,
+  registerRoute: (method: string, path: string, handler: RouteHandler) => void,
+  watch: boolean,
+  logFn: (msg: string) => void
+): Promise<string | undefined> {
+  const { resolveClientEntry, createClientBundler, registerClientBundleRoute, CLIENT_BUNDLE_PATH } = await import('./client-bundler.js')
+  if (resolveClientEntry(projectDir) === null) return undefined
+
+  return await createClientBundler({ projectDir, watch, log: logFn }).match(
+    (bundler) => {
+      registerClientBundleRoute(registerRoute, bundler)
+      logFn(`Client bundle served at ${CLIENT_BUNDLE_PATH}`)
+      return CLIENT_BUNDLE_PATH
+    },
+    (e) => {
+      logFn(`Client bundler failed to start: ${e.message}`)
+      return undefined
+    }
+  )
+}
 
 export async function runStart (): Promise<void> {
   await registerTsxLoader()
@@ -1014,9 +1039,12 @@ export async function runStart (): Promise<void> {
     await loadedConfig.onServer({ server, pool, cms, registerRoute })
   }
 
+  // Bundle and serve the client entry (no-op if the project ships none)
+  const clientBundleUrl = await setupClientBundle(projectDir, registerRoute, false, log)
+
   // Register store routes (no-op if no stores defined)
   const { maybeRegisterStores: maybeRegisterStoresProd } = await import('./store-wiring.js')
-  const storeHydrator = maybeRegisterStoresProd(loadedConfig.stores, registerRoute, undefined, pool, cmsSecret)
+  const storeHydrator = maybeRegisterStoresProd(loadedConfig.stores, registerRoute, undefined, pool, cmsSecret, clientBundleUrl)
 
   // Schema-driven generated route map (custom routes take priority)
   const generatedRoutes = generateCollectionRoutes(userConfig, loadedConfig.routes)

--- a/packages/valence/src/client-bundler.ts
+++ b/packages/valence/src/client-bundler.ts
@@ -1,0 +1,170 @@
+import { join } from 'node:path'
+import { existsSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { context } from 'esbuild'
+import type { BuildContext, BuildResult, Message } from 'esbuild'
+import { ResultAsync } from '@valencets/resultkit'
+import type { RouteHandler } from './define-config.js'
+
+/** Framework-owned URL the bundled client entry is served from. */
+export const CLIENT_BUNDLE_PATH = '/_valence/client.js'
+
+const ENTRY_CANDIDATES = [
+  join('src', 'app', 'client.ts'),
+  join('src', 'app', 'client.js')
+]
+
+export interface ClientBundle {
+  readonly js: string
+  readonly etag: string
+}
+
+export interface ClientBundler {
+  /** Latest good bundle — null before the first successful build. */
+  readonly getBundle: () => ClientBundle | null
+  readonly dispose: () => Promise<void>
+}
+
+export interface ClientBundlerOptions {
+  readonly projectDir: string
+  /** Watch the entry and rebuild on change (dev); one-shot otherwise. */
+  readonly watch: boolean
+  readonly log?: (msg: string) => void
+}
+
+export interface BundleError {
+  readonly message: string
+}
+
+/**
+ * The conventional client entry — the app-layer module that boots stores
+ * (initStores) and any other browser code. Returns null when the project
+ * ships no client code, which disables the bundle route entirely.
+ */
+export function resolveClientEntry (projectDir: string): string | null {
+  for (const candidate of ENTRY_CANDIDATES) {
+    const path = join(projectDir, candidate)
+    if (existsSync(path)) return path
+  }
+  return null
+}
+
+function formatMessages (messages: readonly Message[]): string {
+  return messages.map(m => m.location ? `${m.location.file}:${m.location.line} ${m.text}` : m.text).join('; ')
+}
+
+/**
+ * Bundles the client entry with esbuild into a single browser ESM file,
+ * kept in memory and content-hashed for ETag revalidation. Build failures
+ * never take the server down: the last good bundle keeps serving and the
+ * error is logged; before any good build the route answers 503.
+ */
+export function createClientBundler (options: ClientBundlerOptions): ResultAsync<ClientBundler, BundleError> {
+  const log = options.log ?? (() => {})
+  const entry = resolveClientEntry(options.projectDir)
+
+  let current: ClientBundle | null = null
+  let buildContext: BuildContext | null = null
+
+  const capture = (result: BuildResult): void => {
+    if (result.errors.length > 0) {
+      log(`client bundle failed: ${formatMessages(result.errors)}`)
+      return
+    }
+    const output = result.outputFiles?.[0]
+    if (!output) return
+    const js = output.text
+    current = { js, etag: `"${createHash('sha256').update(js).digest('hex').slice(0, 32)}"` }
+  }
+
+  return ResultAsync.fromPromise(
+    (async (): Promise<ClientBundler> => {
+      if (entry === null) {
+        return {
+          getBundle: () => null,
+          dispose: async () => {}
+        }
+      }
+
+      buildContext = await context({
+        entryPoints: [entry],
+        bundle: true,
+        format: 'esm',
+        platform: 'browser',
+        target: 'es2022',
+        sourcemap: options.watch ? 'inline' : false,
+        minify: !options.watch,
+        write: false,
+        outfile: 'client.js',
+        absWorkingDir: options.projectDir,
+        logLevel: 'silent',
+        plugins: [{
+          name: 'valence-capture',
+          setup (build) {
+            build.onEnd((result) => { capture(result) })
+          }
+        }]
+      })
+
+      // rebuild() rejects on compile errors — onEnd has already logged
+      // them, so a failed first build leaves current at null and the
+      // bundler alive (watch mode recovers on the next file change).
+      await buildContext.rebuild().then(
+        () => undefined,
+        () => undefined
+      )
+
+      if (options.watch) {
+        await buildContext.watch()
+      } else {
+        await buildContext.dispose()
+        buildContext = null
+      }
+
+      return {
+        getBundle: () => current,
+        dispose: async () => {
+          if (buildContext !== null) {
+            await buildContext.dispose()
+            buildContext = null
+          }
+        }
+      }
+    })(),
+    (cause): BundleError => ({ message: cause instanceof Error ? cause.message : 'client bundler failed to start' })
+  )
+}
+
+/**
+ * Serves the in-memory bundle at CLIENT_BUNDLE_PATH with ETag
+ * revalidation — no-cache keeps dev instant while 304s keep it cheap.
+ */
+export function registerClientBundleRoute (
+  registerRoute: (method: string, path: string, handler: RouteHandler) => void,
+  bundler: ClientBundler
+): void {
+  registerRoute('GET', CLIENT_BUNDLE_PATH, async (req: IncomingMessage, res: ServerResponse) => {
+    const bundle = bundler.getBundle()
+    if (bundle === null) {
+      const body = JSON.stringify({ error: { code: 'BUNDLE_UNAVAILABLE', message: 'Client bundle has not built successfully yet — check the server log' } })
+      res.writeHead(503, { 'Content-Type': 'application/json', 'Content-Length': String(Buffer.byteLength(body)) })
+      res.end(body)
+      return
+    }
+
+    if (req.headers['if-none-match'] === bundle.etag) {
+      res.writeHead(304, { ETag: bundle.etag })
+      res.end()
+      return
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'application/javascript; charset=utf-8',
+      'Content-Length': String(Buffer.byteLength(bundle.js)),
+      'Cache-Control': 'no-cache',
+      ETag: bundle.etag
+    })
+    res.end(bundle.js)
+  })
+}

--- a/packages/valence/src/codegen/regenerate.ts
+++ b/packages/valence/src/codegen/regenerate.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path'
 import { existsSync } from 'node:fs'
 import { ResultAsync } from '@valencets/resultkit'
 import type { CollectionConfig } from '@valencets/cms'
+import { store as validateStore, generateStoreModule } from '@valencets/store'
+import type { StoreInput } from '@valencets/store'
 import { generateEntityInterface } from './type-generator.js'
 import { generateApiClient } from './api-client-generator.js'
 import { generateBaseClient } from './base-client-generator.js'
@@ -46,7 +48,8 @@ async function writeIfGenerated (
 
 export function regenerateFromConfig (
   projectDir: string,
-  collections: readonly CollectionConfig[]
+  collections: readonly CollectionConfig[],
+  stores?: readonly StoreInput[]
 ): ResultAsync<RegenResult, ScaffoldError> {
   return ResultAsync.fromPromise(
     (async (): Promise<RegenResult> => {
@@ -65,6 +68,20 @@ export function regenerateFromConfig (
 
         const clientPath = join(entityDir, 'api', 'client.ts')
         await writeIfGenerated(clientPath, generateApiClient(col), tracker)
+      }
+
+      // Regenerate typed store modules — invalid definitions are skipped
+      // here exactly as the route wiring skips them at serve time.
+      const validStores = (stores ?? []).flatMap(input => {
+        const result = validateStore(input)
+        return result.isOk() ? [result.value] : []
+      })
+      if (validStores.length > 0) {
+        await mkdir(join(srcDir, 'shared', 'stores'), { recursive: true })
+        for (const storeConfig of validStores) {
+          const modulePath = join(srcDir, 'shared', 'stores', `${storeConfig.slug}.ts`)
+          await writeIfGenerated(modulePath, generateStoreModule(storeConfig), tracker)
+        }
       }
 
       // Regenerate shared base client

--- a/packages/valence/src/store-wiring.ts
+++ b/packages/valence/src/store-wiring.ts
@@ -157,10 +157,12 @@ export function registerStoreRoutesOnServer (
   const log = options?.log ?? (() => {})
   const hydratable: Array<{ slug: string; scope: string; getState: (session: SessionInfo) => ReturnType<ReturnType<typeof registerStoreRoutes>['getState']> }> = []
 
-  // User-scoped stores persist to postgres; the table is ensured once and
-  // every state query waits on that. Failure degrades loudly, not silently.
-  const wantsPersistence = options?.pool !== undefined &&
-    storeInputs.some(input => input.scope === 'user')
+  // User-scoped stores persist to postgres, as does any store that opts in
+  // via persist: true; the table is ensured once and every state query
+  // waits on that. Failure degrades loudly, not silently.
+  const isPersisted = (input: { readonly scope: string; readonly persist?: boolean }): boolean =>
+    input.scope === 'user' || (input.persist === true && input.scope !== 'page')
+  const wantsPersistence = options?.pool !== undefined && storeInputs.some(isPersisted)
   const tableReady: Promise<void> = wantsPersistence
     ? options!.pool!.query(STORE_STATES_DDL).then(
       () => undefined,
@@ -187,7 +189,7 @@ export function registerStoreRoutesOnServer (
     }
 
     let holder: StateBackend = SessionStateHolder.create(config.fields)
-    if (config.scope === 'user' && options?.pool) {
+    if (isPersisted(config) && options?.pool) {
       const gatedPool: StorePool = {
         query: async (...args: readonly string[]) => {
           await tableReady

--- a/packages/valence/src/store-wiring.ts
+++ b/packages/valence/src/store-wiring.ts
@@ -139,6 +139,9 @@ export interface StoreWiringOptions {
   readonly secret?: string
   /** Resolves a cms_session token to a userId, or null when invalid */
   readonly validateCmsSession?: (sessionId: string) => Promise<string | null>
+  /** URL of the bundled client entry — when set, store-referencing pages
+   *  get a module script tag injected alongside their hydration tags. */
+  readonly clientScriptUrl?: string
 }
 
 /**
@@ -299,16 +302,21 @@ export function registerStoreRoutesOnServer (
     const referenced = hydratable.filter(entry => html.includes(`data-store="${entry.slug}"`))
     if (referenced.length === 0) return html
 
-    const identity = await resolveIdentity(req, res, options)
-    if (identity === null) return html
-
     let tags = ''
-    for (const entry of referenced) {
-      // Anonymous visitors get no user-scoped state — the client falls back
-      // to its authenticated fetch path, which enforces 403 properly.
-      if (entry.scope === 'user' && identity.userId === undefined) continue
-      const state = await entry.getState(identity)
-      tags += renderStoreHydration(entry.slug, state)
+    const identity = await resolveIdentity(req, res, options)
+    if (identity !== null) {
+      for (const entry of referenced) {
+        // Anonymous visitors get no user-scoped state — the client falls back
+        // to its authenticated fetch path, which enforces 403 properly.
+        if (entry.scope === 'user' && identity.userId === undefined) continue
+        const state = await entry.getState(identity)
+        tags += renderStoreHydration(entry.slug, state)
+      }
+    }
+    // The runtime ships with the page that needs it — module scripts defer
+    // until the DOM (including the hydration tags above) is parsed.
+    if (options?.clientScriptUrl !== undefined) {
+      tags += `<script type="module" src="${options.clientScriptUrl}"></script>`
     }
     if (tags.length === 0) return html
 
@@ -325,12 +333,14 @@ export function maybeRegisterStores (
   registerRoute: (method: string, path: string, handler: RouteHandler) => void,
   logFn?: (msg: string) => void,
   dbPool?: DbPool,
-  secret?: string
+  secret?: string,
+  clientScriptUrl?: string
 ): StoreHydrator | undefined {
   if (!stores || stores.length === 0) return undefined
   const options: StoreWiringOptions = {
     ...(logFn ? { log: logFn } : {}),
     ...(secret !== undefined ? { secret } : {}),
+    ...(clientScriptUrl !== undefined ? { clientScriptUrl } : {}),
     ...(dbPool
       ? {
           pool: {

--- a/packages/valence/valence.api.md
+++ b/packages/valence/valence.api.md
@@ -258,6 +258,7 @@ export type StoreHydrator = (req: IncomingMessage, res: ServerResponse, html: st
 
 // @public (undocumented)
 export interface StoreWiringOptions {
+    readonly clientScriptUrl?: string;
     // (undocumented)
     readonly log?: (msg: string) => void;
     // (undocumented)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
       '@valencets/telemetry':
         specifier: workspace:*
         version: link:../telemetry
+      esbuild:
+        specifier: ^0.27.0
+        version: 0.27.4
       tsx:
         specifier: ^4.21.0
         version: 4.21.0


### PR DESCRIPTION
Closes the three gaps between the store feature and a buildable MVP app, identified while scoping the Enshrouded server-config dogfood.

## 1. Client runtime delivery

The server side of stores was complete, but nothing shipped `@valencets/store/client` to the browser — apps had no bundler story at all.

- New `client-bundler.ts`: esbuild bundles the conventional client entry (`src/app/client.ts` or `.js`) into a single browser ESM file, kept in memory and content-hashed.
- `valence dev` watches and rebuilds on change (inline source maps); `valence start` bundles once at boot (minified). Both serve it at `/_valence/client.js` with ETag revalidation (`304` on match, `no-cache`).
- The store hydrator injects `<script type="module" src="/_valence/client.js"></script>` on pages that reference a store via `data-store` — same condition as hydration tags, exactly once per page. Pages without store references stay byte-identical.
- A compile error never takes the server down: the route answers 503 until the first good build, the last good bundle keeps serving after one, and watch mode recovers on the next file change.
- esbuild added as an explicit dependency of `@valencets/valence` (already in the tree transitively via tsx; 0.27.x resolves once).

## 2. Store codegen wired into the CLI

`generateStoreModule` existed but nothing called it — collections got generated types, stores didn't.

- `generateStoreModule` is now exported from the `@valencets/store` barrel.
- `regenerateFromConfig` accepts the config's stores and writes a typed module per store to `src/shared/stores/<slug>.ts` (FSD shared layer), respecting the `// @generated` marker so user-edited files are never overwritten. Invalid definitions are skipped exactly as the route wiring skips them.
- Both CLI config-watcher call sites pass `cfg.stores` through.

## 3. `persist` option — durable anonymous state

`user` scope was postgres-backed; `session`/`global` were memory-only, so anonymous state died on restart or LRU eviction. Persistence is now orthogonal to audience:

```ts
{ slug: 'server-config', scope: 'session', persist: true, fields: [...] }
```

- Persisted session stores write through to `store_states` keyed by the signed session id; persisted global stores key one row as `__global__`. The table is ensured once at boot, same as user scope.
- `persist: true` on `page` scope is a definition error (`INVALID_PERSIST`) — page stores have no server state to persist.
- Without a pool, persist-flagged stores degrade to in-memory exactly like user scope does.
- Anonymous rows are not auto-expired; pruning by `updated_at` is documented as the app's job.

## Verification

- 5 TDD RED/GREEN pairs; `check:tdd-sequence` green.
- 351 store + 471 valence unit tests, 3,976 across all 12 packages.
- 50/50 integration tests against a real postgres 16.
- Build, lint, `check:patterns`, api baselines all green (baseline refreshed for the new `clientScriptUrl` wiring option).

`docs/STORES.md` gains a "Client delivery" section, the `persist` scope-table addendum, and the codegen output location.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDPG7XK7hEnaanNWzJfo42)_