### PR TITLE
fix(db,store): three real-driver bugs caught by dogfooding a fresh app

### DIFF
--- a/packages/db/src/__tests__/migration-runner.test.ts
+++ b/packages/db/src/__tests__/migration-runner.test.ts
@@ -231,7 +231,6 @@ describe('runMigrations edge cases', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: async (): Promise<ReadonlyArray<Record<string, number>>> => [],
-        begin: async (): Promise<void> => {},
         release: async (): Promise<void> => {}
       }
     )
@@ -239,7 +238,6 @@ describe('runMigrations edge cases', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: async (): Promise<ReadonlyArray<Record<string, number>>> => [],
-        begin: async (): Promise<void> => {},
         reserve: async () => reservedSql
       }
     ) as unknown as import('../connection.js').DbPool['sql']
@@ -254,7 +252,6 @@ describe('runMigrations advisory lock', () => {
   it('uses one reserved connection for lock, migration execution, and unlock', async () => {
     const rootCalls: string[] = []
     const reservedCalls: string[] = []
-    const txCalls: string[] = []
 
     const reservedUnsafe = async (query: string): Promise<ReadonlyArray<Record<string, number>>> => {
       reservedCalls.push(query)
@@ -265,14 +262,6 @@ describe('runMigrations advisory lock', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: reservedUnsafe,
-        begin: async (fn: (tx: { unsafe: typeof reservedUnsafe }) => Promise<void>): Promise<void> => {
-          await fn({
-            unsafe: async (query: string): Promise<ReadonlyArray<Record<string, number>>> => {
-              txCalls.push(query)
-              return []
-            }
-          })
-        },
         release: async (): Promise<void> => {}
       }
     )
@@ -284,7 +273,6 @@ describe('runMigrations advisory lock', () => {
           rootCalls.push(query)
           return []
         },
-        begin: async (): Promise<void> => {},
         reserve: async () => reservedSql
       }
     ) as unknown as import('../connection.js').DbPool['sql']
@@ -298,15 +286,27 @@ describe('runMigrations advisory lock', () => {
     expect(rootCalls).toEqual([])
     expect(reservedCalls.some((query) => query.includes('pg_advisory_lock'))).toBe(true)
     expect(reservedCalls.some((query) => query.includes('pg_advisory_unlock'))).toBe(true)
-    expect(txCalls).toContain('CREATE TABLE test (id INT);')
+    // The migration and its bookkeeping run inside one explicit transaction
+    // on the reserved connection — postgres.js reserved connections expose
+    // no begin(), so the runner must issue BEGIN/COMMIT itself.
+    const beginIndex = reservedCalls.indexOf('BEGIN')
+    const migrationIndex = reservedCalls.indexOf('CREATE TABLE test (id INT);')
+    const insertIndex = reservedCalls.findIndex((query) => query.includes('INSERT INTO _migrations'))
+    const commitIndex = reservedCalls.indexOf('COMMIT')
+    expect(beginIndex).toBeGreaterThanOrEqual(0)
+    expect(migrationIndex).toBeGreaterThan(beginIndex)
+    expect(insertIndex).toBeGreaterThan(migrationIndex)
+    expect(commitIndex).toBeGreaterThan(insertIndex)
   })
 
-  it('releases the advisory lock on the reserved connection when a migration fails', async () => {
+  it('rolls back and releases the advisory lock when a migration fails', async () => {
     const reservedCalls: string[] = []
-    const txCalls: string[] = []
 
     const reservedUnsafe = async (query: string): Promise<ReadonlyArray<Record<string, number>>> => {
       reservedCalls.push(query)
+      if (query === 'CREATE TABLE test (id INT);') {
+        throw new Error('boom')
+      }
       return []
     }
 
@@ -314,14 +314,6 @@ describe('runMigrations advisory lock', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: reservedUnsafe,
-        begin: async (fn: (tx: { unsafe: typeof reservedUnsafe }) => Promise<void>): Promise<void> => {
-          await fn({
-            unsafe: async (query: string): Promise<ReadonlyArray<Record<string, number>>> => {
-              txCalls.push(query)
-              throw new Error('boom')
-            }
-          })
-        },
         release: async (): Promise<void> => {}
       }
     )
@@ -330,7 +322,6 @@ describe('runMigrations advisory lock', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: async (): Promise<ReadonlyArray<Record<string, number>>> => [],
-        begin: async (): Promise<void> => {},
         reserve: async () => reservedSql
       }
     ) as unknown as import('../connection.js').DbPool['sql']
@@ -341,9 +332,14 @@ describe('runMigrations advisory lock', () => {
     ])
 
     expect(result.isErr()).toBe(true)
-    expect(txCalls).toContain('CREATE TABLE test (id INT);')
+    expect(reservedCalls).toContain('CREATE TABLE test (id INT);')
+    // The failed statement's transaction is rolled back on the same
+    // connection before the lock is surrendered.
+    const rollbackIndex = reservedCalls.indexOf('ROLLBACK')
+    const unlockIndex = reservedCalls.findIndex((query) => query.includes('pg_advisory_unlock'))
+    expect(rollbackIndex).toBeGreaterThan(reservedCalls.indexOf('BEGIN'))
+    expect(unlockIndex).toBeGreaterThan(rollbackIndex)
     expect(reservedCalls.some((query) => query.includes('pg_advisory_lock'))).toBe(true)
-    expect(reservedCalls.some((query) => query.includes('pg_advisory_unlock'))).toBe(true)
   })
 
   it('attempts release when advisory unlock fails', async () => {
@@ -362,7 +358,6 @@ describe('runMigrations advisory lock', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: reservedUnsafe,
-        begin: async (): Promise<void> => {},
         release: async (): Promise<void> => {
           releaseCalls++
         }
@@ -373,7 +368,6 @@ describe('runMigrations advisory lock', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: async (): Promise<ReadonlyArray<Record<string, number>>> => [],
-        begin: async (): Promise<void> => {},
         reserve: async () => reservedSql
       }
     ) as unknown as import('../connection.js').DbPool['sql']
@@ -392,6 +386,9 @@ describe('runMigrations advisory lock', () => {
       if (query.includes('pg_advisory_unlock')) {
         throw new Error('unlock failed')
       }
+      if (query === 'CREATE TABLE test (id INT);') {
+        throw new Error('migration failed')
+      }
       return []
     }
 
@@ -399,13 +396,6 @@ describe('runMigrations advisory lock', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: reservedUnsafe,
-        begin: async (fn: (tx: { unsafe: typeof reservedUnsafe }) => Promise<void>): Promise<void> => {
-          await fn({
-            unsafe: async (): Promise<ReadonlyArray<Record<string, number>>> => {
-              throw new Error('migration failed')
-            }
-          })
-        },
         release: async (): Promise<void> => {
           releaseCalls++
         }
@@ -416,7 +406,6 @@ describe('runMigrations advisory lock', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: async (): Promise<ReadonlyArray<Record<string, number>>> => [],
-        begin: async (): Promise<void> => {},
         reserve: async () => reservedSql
       }
     ) as unknown as import('../connection.js').DbPool['sql']
@@ -440,7 +429,6 @@ describe('runMigrations advisory lock', () => {
           }
           return []
         },
-        begin: async (): Promise<void> => {},
         release: async (): Promise<void> => {
           throw new Error('release failed')
         }
@@ -451,7 +439,6 @@ describe('runMigrations advisory lock', () => {
       async (): Promise<ReadonlyArray<Record<string, number>>> => [],
       {
         unsafe: async (): Promise<ReadonlyArray<Record<string, number>>> => [],
-        begin: async (): Promise<void> => {},
         reserve: async () => reservedSql
       }
     ) as unknown as import('../connection.js').DbPool['sql']

--- a/packages/db/src/migration-runner.ts
+++ b/packages/db/src/migration-runner.ts
@@ -155,13 +155,28 @@ function runMigrationsWithLock (pool: DbPool, migrations: ReadonlyArray<Migratio
             continue
           }
 
-          await reservedSql.begin(async (tx) => {
-            await tx.unsafe(migration.sql)
-            await tx.unsafe(
+          // postgres.js reserved connections expose no begin() — the
+          // transaction is issued explicitly so it stays on the same
+          // connection that holds the advisory lock.
+          await reservedSql.unsafe('BEGIN')
+          const failure: unknown = await (async () => {
+            await reservedSql.unsafe(migration.sql)
+            await reservedSql.unsafe(
               'INSERT INTO _migrations (version, name) VALUES ($1, $2)',
               [migration.version, migration.name]
             )
-          })
+          })().then(
+            () => null,
+            (cause: unknown) => cause instanceof Error ? cause : new Error(`migration ${migration.version} failed`)
+          )
+
+          if (failure !== null) {
+            // Surface the original failure even if the rollback also fails
+            await reservedSql.unsafe('ROLLBACK').then(() => undefined, () => undefined)
+            await Promise.reject(failure)
+          }
+
+          await reservedSql.unsafe('COMMIT')
           count++
         }
 


### PR DESCRIPTION
Dogfooding a fresh `valence init` app (Enshrouded server-config generator) against a real postgres 16 surfaced three bugs that unit-test mocks had been papering over. All three are fixed here with tests that model the real driver.

## 1. Migration runner calls `begin()` on a reserved connection that has none

**Every real migration run fails** with `TypeError: reservedSql.begin is not a function`, breaking `valence migrate` and `valence start` for any project with pending migrations. postgres.js reserved connections expose `unsafe`/`release` — no `begin` (see `postgres/src/index.js` `reserve()`). The unit mocks fabricated a `begin` method, so CI verified our wishful model of the driver instead of the driver.

Fix: issue `BEGIN`/`COMMIT`/`ROLLBACK` explicitly through `reservedSql.unsafe`, keeping the transaction on the connection that holds the session-scoped advisory lock. RED rewrites the mocks to the driver's real surface and asserts ordering (`BEGIN` → migration → bookkeeping INSERT → `COMMIT`; rollback before unlock on failure).

## 2. Persisted store state lands as a double-encoded jsonb string

`PostgresStateHolder.setState` passes `JSON.stringify(state)` as a parameter cast to `::jsonb`. postgres.js infers json for that parameter and JSON-encodes the JS string again, so the column holds `jsonb_typeof = 'string'` — not an object. `getState` then fails its object check and silently falls back to field defaults: **every mutation on a persisted store started from scratch**, while returning `ok: true`. The unit-test pool mock `JSON.parse`d the parameter, modeling post-fix semantics that reality didn't have.

Fix: `($3::jsonb #>> '{}')::jsonb` in the UPSERT — unwraps the string case (postgres.js) and round-trips the object case (drivers that send plain text), so state always lands as a queryable jsonb object.

RED is a new **integration suite** (`tests/integration/store-persistence.integration.test.ts`) that runs the holder and `handleMutation` against real postgres through the exact `sql.unsafe` adapter valence builds — asserts `jsonb_typeof(state) = 'object'` and that mutations accumulate across round-trips. This class of bug (mock drift) has now bitten twice in one day; the store persistence path is integration-tested from here on.

## 3. Generated store modules import types the barrel doesn't export

`generateStoreModule` emits `import type { ..., StoreValue } from '@valencets/store'`, but the barrel never exported `StoreValue` (or `StoreState`/`MutationInput`) — every generated module failed `tsc` in a consuming app. Fix: export them; RED asserts every type name the codegen emits exists in the barrel.

## Verification

- db: 100/100 unit tests against faithful reserved-connection mocks.
- store: 351/351 unit tests; new integration suite 3/3 against postgres 16.
- End-to-end on the dogfood app: `valence migrate` applies migrations, session-persisted store state survives mutations, restarts, and reads back as queryable jsonb; `tsc` passes on an app importing generated modules.