### PR TITLE
fix(release): make the npm release actually installable — publish store, pin scaffold deps, bump versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,7 +569,7 @@ jobs:
       - run: pnpm build
       - name: Publish packages
         run: |
-          for pkg in packages/ui packages/core packages/db packages/reactive packages/telemetry packages/cms packages/graphql packages/plugin-cloud-storage packages/valence; do
+          for pkg in packages/ui packages/core packages/db packages/reactive packages/telemetry packages/cms packages/graphql packages/plugin-cloud-storage packages/store packages/valence; do
             cd "$GITHUB_WORKSPACE/$pkg"
             VERSION=$(node -p "require('./package.json').version")
             NAME=$(node -p "require('./package.json').name")
@@ -600,7 +600,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for pkg in packages/ui packages/core packages/db packages/reactive packages/telemetry packages/cms packages/graphql packages/plugin-cloud-storage packages/valence; do
+          for pkg in packages/ui packages/core packages/db packages/reactive packages/telemetry packages/cms packages/graphql packages/plugin-cloud-storage packages/store packages/valence; do
             VERSION=$(node -p "require('./$pkg/package.json').version")
             NAME=$(node -p "require('./$pkg/package.json').name")
             SHORT=$(echo "$NAME" | sed 's/@valencets\///')

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 
-<p align="center"><strong>Schema-driven full-stack framework for Node.js and PostgreSQL.</strong></p>
+<p align="center"><strong>The schema-driven web framework. One TypeScript config. The whole stack derived.</strong></p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@valencets/valence"><img src="https://img.shields.io/npm/v/@valencets/valence" alt="npm"></a>
@@ -22,108 +22,80 @@
 
 > **Status: Pre-1.0.** Valence is in active development. The API surface is stabilizing but breaking changes may occur. Security hardening and package-by-package audits are ongoing.
 
-Define collections and fields in one TypeScript config. Valence derives database tables, a server-rendered admin panel, REST and GraphQL APIs, typed routes with loaders and actions, entity codegen, database migrations, and a first-party analytics pipeline from that single schema. No runtime framework on public pages. No vendor scripts. Minimal, audited dependencies.
+## The premise
+
+Modern web development stacks frameworks on frameworks: a rendering library, a state manager, a data-fetching cache, a form library, a bundler to hold it together, and a vendor script for analytics — each with its own mental model, each redescribing the same data the last layer already knew about. Every layer is a place for the description of your application to drift out of sync with the application itself.
+
+Valence makes one bet instead: **describe the application once, and derive everything from that description.**
+
+- **The schema is law.** Collections, fields, stores, and routes live in one `valence.config.ts`. Database tables, migrations, a server-rendered admin panel, REST and GraphQL APIs, Zod validation on both sides of the wire, typed entity clients, and live shared state are all *derived* — never hand-synchronized. If it isn't in the schema, it doesn't exist; if it is, everything downstream already knows.
+- **The server is true.** State changes are mutations that carry *intent* — "add this item", not "here is my copy of the world." The server validates, linearizes, and answers with authoritative state; clients apply optimistic updates and rebase their pending work on every answer. No stale caches to invalidate, no client-side source-of-truth to reconcile by hand.
+- **The browser is enough.** Public pages ship server-rendered HTML and zero third-party JavaScript. Interactivity comes from what the platform already provides — Web Components, signals over `Proxy`, `EventSource` for push, `fetch` for mutations, `data-*` attributes for wiring. There is no virtual DOM, no hydration waterfall, no framework runtime to ship, version, and eventually migrate away from.
+- **Discipline is a feature.** Everything that can fail returns `Result<T, E>` — both branches handled, enforced by lint. Functions stay under complexity 20. Features land as failing-test-first commits, checked by CI. The point isn't ceremony; it's that errors stay *legible* in a codebase meant to outlive its authors' attention.
+
+## One schema
 
 ```typescript
 // valence.config.ts
 import { defineConfig, collection, field } from '@valencets/valence'
+import { field as storeField } from '@valencets/store'
 
 export default defineConfig({
-  db: {
-    host: process.env.DB_HOST ?? 'localhost',
-    port: Number(process.env.DB_PORT ?? 5432),
-    database: process.env.DB_NAME ?? 'mysite',
-    username: process.env.DB_USER ?? 'postgres',
-    password: process.env.DB_PASSWORD ?? 'postgres',
-    sslmode: process.env.DB_SSLMODE as 'disable' | 'require' | 'verify-ca' | 'verify-full' | undefined,
-    sslrootcert: process.env.DB_SSLROOTCERT
-  },
-  server: { port: Number(process.env.PORT ?? 3000) },
+  db: { /* postgres connection */ },
+  server: { port: 3000 },
+
   collections: [
     collection({
       slug: 'posts',
-      labels: { singular: 'Post', plural: 'Posts' },
       versions: { drafts: true },
-      hooks: {
-        afterChange: [({ doc }) => console.log('saved', doc.id)]
-      },
       fields: [
         field.text({ name: 'title', required: true }),
         field.slug({ name: 'slug', slugFrom: 'title', unique: true }),
         field.richtext({ name: 'body' }),
-        field.tabs({
-          tabs: [
-            {
-              label: 'Details',
-              fields: [
-                field.boolean({ name: 'published' }),
-                field.date({ name: 'publishedAt', condition: (data) => data.published === 'true' })
-              ]
-            },
-            {
-              label: 'SEO',
-              fields: [
-                field.text({ name: 'metaTitle' }),
-                field.textarea({ name: 'metaDescription' })
-              ]
-            }
-          ]
-        })
+        field.boolean({ name: 'published' })
       ]
     }),
     collection({
       slug: 'users',
       auth: true,
-      fields: [
-        field.text({ name: 'name', required: true }),
-        field.select({
-          name: 'role',
-          defaultValue: 'editor',
-          access: { update: ({ user }) => user.role === 'admin' },
-          options: [
-            { label: 'Admin', value: 'admin' },
-            { label: 'Editor', value: 'editor' }
-          ]
-        })
-      ]
+      fields: [field.text({ name: 'name', required: true })]
     })
   ],
-  routes: [
-    {
-      path: '/blog/:slug',
-      collection: 'posts',
-      type: 'detail',
-      loader: async ({ params, pool }) => {
-        const post = await pool`SELECT * FROM posts WHERE slug = ${params.slug}`
-        return { data: { post: post[0] } }
+
+  stores: [{
+    slug: 'cart',
+    scope: 'session',        // who shares this state: page | session | user | global
+    persist: true,           // survive restarts in postgres
+    fields: [storeField.array({ name: 'items', fields: [/* … */] })],
+    mutations: {
+      addItem: {
+        input: [storeField.text({ name: 'sku', required: true })],
+        server: async ({ state, input, pool }) => { /* the one source of truth */ },
+        client: ({ state, input }) => { /* optional zero-latency optimism */ }
       }
     },
-    {
-      path: '/contact',
-      method: 'POST',
-      action: async ({ body }) => {
-        return { redirect: '/thank-you' }
-      }
+    fragment: (state) => `<span class="badge">${(state.items as unknown[]).length}</span>`
+  }],
+
+  routes: [{
+    path: '/blog/:slug',
+    collection: 'posts',
+    type: 'detail',
+    loader: async ({ params, pool }) => {
+      const post = await pool`SELECT * FROM posts WHERE slug = ${params.slug}`
+      return { data: { post: post[0] } }
     }
-  ],
-  onServer ({ server, pool, cms, registerRoute }) {
-    registerRoute('GET', '/api/health', (_req, res) => {
-      res.writeHead(200).end('ok')
-    })
-  },
+  }],
+
   admin: { pathPrefix: '/admin', requireAuth: true },
   graphql: true,
-  telemetry: {
-    enabled: true,
-    endpoint: '/api/telemetry',
-    siteId: 'mysite'
-  }
+  telemetry: { enabled: true, endpoint: '/api/telemetry', siteId: 'mysite' }
 })
 ```
 
-That config gives you: `posts` and `users` tables in Postgres, a server-rendered admin panel with form validation and session auth (Argon2id), a REST API at `/api/posts` and `/api/users`, a GraphQL endpoint at `/graphql`, typed routes with loaders and actions, an `onServer` hook for custom routes and WebSocket handlers, a typed `src/` scaffold with entity interfaces and API clients, Zod validators, database migrations, draft versioning with revision history, and a first-party analytics pipeline that tracks user intent without any third-party scripts on your public pages. One schema to rule them all.
+That one file yields: `posts` and `users` tables with migrations, a server-rendered admin panel with drafts, revision history, and Argon2id session auth, a REST API at `/api/posts`, a GraphQL endpoint, typed routes with loaders and actions, generated entity interfaces and API clients, a live `cart` shared across the visitor's tabs and server restarts, and first-party analytics running entirely in your Postgres.
 
-## Quick Start
+## Quick start
 
 ```bash
 npx @valencets/valence init my-site
@@ -131,116 +103,83 @@ cd my-site
 pnpm dev
 ```
 
-The init wizard walks you through database setup, admin user creation, optional seed data, and framework choice (plain HTML templates, Astro, or bring your own). Pass `--yes` to skip prompts and accept defaults.
+The wizard walks through database setup and options; it works identically in a terminal, a heredoc, or CI. Pass `--yes` for defaults, with granular `--no-install`, `--no-db`, `--no-migrate`, `--no-seed`, `--no-git` skips. Open `http://localhost:3000/admin` to sign in.
 
-Open `http://localhost:3000/admin` to sign in. Open `http://localhost:3000` for the landing page.
+## State without a framework
 
-## What You Get
+The store system is where the bet pays off most visibly. A store declares its **scope** — the social radius of its state — and the framework derives the storage backend, the identity requirements, and exactly who receives live updates:
 
-### Schema Engine
+| Scope | Server state | Who gets live updates |
+|---|---|---|
+| `page` | none — typed, validated signals only | — |
+| `session` | in-memory, or postgres with `persist: true` | the visitor's other tabs |
+| `user` | postgres, keyed by verified user id | every device the user is signed in on |
+| `global` | one shared copy | every connected client |
 
-- **Database tables** derived from your field definitions. UUID primary keys, timestamps, soft deletes.
-- **22 field types.** text, textarea, richtext, number, boolean, select, date, slug, media, relation, group, email, url, password, json, color, multiselect, array, blocks, tabs, row, collapsible.
-- **Layout fields.** Tabs, rows, and collapsible sections for organizing complex admin forms without affecting the database schema.
-- **Conditional fields.** Show or hide fields based on other field values using the `condition` function.
-- **Field access control.** Per-field create, read, and update access control functions that receive the current user context.
-- **Field hooks.** `beforeValidate`, `beforeChange`, `afterChange`, `afterRead` hooks on individual fields.
-- **Globals.** Single-document configs (site settings, navigation, footer) via `global()` with the same field system.
-- **Migrations** generated from schema diffs. Deterministic SQL, idempotent, version-tracked.
+Pages bind to stores declaratively — the store is named once on a container and everything inside inherits it:
 
-### Admin Panel
+```html
+<section data-store="cart">
+  <fieldset data-commit="updateQuantity">
+    <input data-field="qty" type="number">   <!-- two-way, schema-coerced -->
+  </fieldset>
+  <button data-mutation="addItem" data-args='{"sku":"abc"}'>Add to cart</button>
+  <div data-fragment></div>                   <!-- server-rendered live preview -->
+</section>
+```
 
-- **Server-rendered** admin at `/admin`. HTML forms, CSRF protection, session auth with Argon2id.
-- **Rich text editor.** Tiptap-powered (ProseMirror) with heading, list, blockquote, link, code, divider, and code block formatting. Slash command menu for block insertion.
-- **Draft versioning.** Enable `versions: { drafts: true }` on a collection for publish/unpublish workflow with revision history and diff view.
-- **Autosave.** Automatic draft saving with visual indicator via the `<val-autosave>` component.
-- **Live preview.** Split-pane editor with real-time preview iframe via postMessage.
-- **Bulk operations.** Select multiple documents in list view for bulk delete, publish, or unpublish.
-- **Image processing.** Automatic image resizing and optimization via Sharp on media upload.
+`data-field` binds controls to store fields both ways with coercion driven by the schema. `data-mutation` buttons fire named mutations with pending/error affordances. `data-fragment` receives server-rendered HTML over SSE — LiveView-style — while signal-mode components on the same page read the same state through `@valencets/reactive`. Anonymous visitors get HMAC-signed sessions from first paint; authenticated users get state that follows them across devices. The client bundle is built and served by the framework — drop a `src/app/client.ts` in your project and `valence dev` handles esbuild, watching, and script injection.
 
-### API Layer
+## What you get
 
-- **REST API** at `/api/:collection`. CRUD with Zod validation, parameterized queries, `Result<T, E>` error handling.
-- **GraphQL API.** Auto-generated schema from collections with resolvers wired to the Local API. Enable with `graphql: true`.
-- **Local API.** Programmatic access to all CRUD operations with the same validation and hooks as the REST layer.
-- **Full-text search.** PostgreSQL tsvector/tsquery with relevance ranking, configurable per collection.
+**Schema engine** — 22 field types (text through richtext, relations, media, blocks, tabs), conditional fields, per-field access control and hooks, globals, and migrations generated from schema diffs.
 
-### Routing
+**Admin panel** — server-rendered at `/admin`: Tiptap rich text, draft versioning with diff view, autosave, live preview, bulk operations, Sharp image processing. CSRF-protected forms, Argon2id sessions.
 
-- **Page routing.** `src/pages/` maps to URL paths.
-- **Routes with loaders.** Server-side data loading injected into pages.
-- **Routes with actions.** Form handling that returns redirects or field-level errors.
-- **`onServer` hook.** Access the raw `http.Server`, database pool, CMS instance, and `registerRoute` for custom endpoints or WebSocket upgrade handlers.
-- **View transitions.** Built-in presets for smooth page navigation.
+**API layer** — REST with Zod validation and collection-level `access` control, auto-generated GraphQL, a Local API sharing the same validation and hooks, and Postgres full-text search.
 
-### Frontend
+**Routing** — `src/pages/` file routing, loaders and actions, an `onServer` escape hatch for custom endpoints and WebSockets, view transitions.
 
-- **23 Web Components.** ARIA-compliant, i18n-ready, telemetry hooks, hydration directives. OKLCH design tokens. Zero dependencies.
-- **Entity codegen.** Typed interfaces and API clients generated from your schema. `// @generated` files regenerate on config change; user-edited files are never overwritten.
-- **Static file serving.** `public/` served with MIME types and path traversal protection.
+**Frontend** — 23 dependency-free, ARIA-compliant Web Components with OKLCH design tokens and light/dark theming (`<html data-theme="dark">`); a signals package with two-way DOM bindings that work on native inputs and ValElements alike; typed entity clients and store modules regenerated on every config change.
 
-### Security
+**Telemetry** — first-party analytics in your own Postgres. `data-telemetry-*` attributes, a pre-allocated ring buffer on the client, `sendBeacon` flushes, daily aggregation. No third-party scripts, ever.
 
-- Argon2id password hashing for admin authentication.
-- CSRF protection on admin forms (double-submit cookie with `crypto.randomBytes`).
-- Session auth with `httpOnly`, `Secure`, `SameSite=Strict` cookie flags.
-- Path traversal protection on static file serving, media uploads, and cloud storage.
-- URL redirect validation to prevent open redirect attacks.
-- Parameterized SQL everywhere. No string concatenation in queries.
-- CodeQL and Socket auditing in CI.
-
-### Telemetry
-
-First-party analytics that runs entirely in your Postgres. No Google Analytics, no Plausible, no third-party scripts on your public pages. Your data stays in your database.
-
-Annotate HTML elements with `data-telemetry-*` attributes. The client library captures events in a pre-allocated ring buffer (zero allocation in the hot path) and auto-flushes via `navigator.sendBeacon()`. The server ingests payloads, stores raw events, and aggregates into daily summaries.
-
-11 intent types: CLICK, SCROLL, VIEWPORT_INTERSECT, FORM_INPUT, INTENT_NAVIGATE, INTENT_CALL, INTENT_BOOK, INTENT_LEAD, LEAD_PHONE, LEAD_EMAIL, LEAD_FORM.
-
-### Plugins
-
-- `@valencets/plugin-seo` — auto-title, meta field injection.
-- `@valencets/plugin-nested-docs` — tree structures with breadcrumb computation.
-- `@valencets/plugin-cloud-storage` — S3-compatible object storage adapter.
-
-Plugins are config transformers: a function that receives a `CmsConfig` and returns a modified `CmsConfig`.
+**Security** — Argon2id, CSRF double-submit, `httpOnly`/`Secure`/`SameSite` sessions, HMAC-signed anonymous store sessions, path-traversal protection, parameterized SQL everywhere, CodeQL and Socket audits in CI.
 
 ## Packages
 
 | Package | What it does | External deps |
 |---------|-------------|---------------|
-| `@valencets/ui` | 23 Web Components. ARIA, i18n, telemetry hooks, hydration directives. OKLCH tokens. | none |
-| `@valencets/core` | Router + server. pushState nav, fragment swaps, prefetch, view transitions, server islands. | @valencets/resultkit |
-| `@valencets/db` | PostgreSQL query layer. Tagged template SQL, validated config, explicit SSL modes, Result-based error mapping, migration runner. | postgres, @valencets/resultkit, zod |
-| `@valencets/cms` | Schema engine. `collection()` + `field.*` produces tables, validators, REST API, admin UI, auth, media. Rich text via Tiptap. | tiptap, argon2, sharp, zod, @valencets/resultkit |
-| `@valencets/graphql` | Auto-generated GraphQL schema + resolvers from CMS collections. | graphql, @valencets/resultkit |
-| `@valencets/telemetry` | Beacon ingestion, event storage, daily summaries, consent-aware aggregation, retention cleanup. | postgres, @valencets/resultkit |
-| `@valencets/reactive` | Zero-dependency signals package used by newer admin/login flows and available for app/runtime usage. | none |
-| `@valencets/valence` | CLI + FSD scaffold + entity codegen + route types. | tsx, zod, @valencets/resultkit |
+| `@valencets/valence` | CLI, dev/prod server, scaffold, codegen, client bundling. | esbuild, tsx, zod, @valencets/resultkit |
+| `@valencets/cms` | Schema engine: tables, validators, REST, admin UI, auth, media. | tiptap, argon2, sharp, zod, @valencets/resultkit |
+| `@valencets/store` | Schema-driven shared state: scopes, mutations, SSE, optimistic updates, declarative binding. | zod, @valencets/resultkit |
+| `@valencets/ui` | 23 Web Components. ARIA, i18n, telemetry hooks, hydration directives, OKLCH tokens. | none |
+| `@valencets/reactive` | Signals, computed, effects, DOM bindings. | none |
+| `@valencets/core` | Router + server: pushState nav, fragment swaps, prefetch, view transitions. | @valencets/resultkit |
+| `@valencets/db` | Postgres layer: tagged-template SQL, Result-based errors, migration runner. | postgres, zod, @valencets/resultkit |
+| `@valencets/graphql` | GraphQL schema + resolvers derived from collections. | graphql, @valencets/resultkit |
+| `@valencets/telemetry` | Beacon ingestion, aggregation, retention. | postgres, @valencets/resultkit |
 
-Core external runtime deps: 8. All MIT-licensed, all audited via Socket. Public-facing pages ship zero third-party JavaScript.
+All MIT-licensed, all audited via Socket. Public-facing pages ship zero third-party JavaScript.
 
-## Constraints
+## The discipline is the product
 
 | Rule | Why |
 |------|-----|
+| `Result<T, E>` everywhere | If it can fail, the type says so — and lint refuses `throw`, `try/catch`, and unhandled branches. |
 | Complexity < 20 | Every function fits on one screen. |
-| `Result<T, E>` everywhere | If it can fail, the type says so. Both branches handled. |
+| Test-first commits | RED test, then GREEN implementation — checked by CI, not by convention. |
 | 14kB critical shell | First paint in the first TCP round trip. |
-| Pre-allocated ring buffer | Zero allocation in the telemetry hot path. |
 | Zero third-party JS on public pages | Your site ships your code. Tiptap is admin-only. |
-| 3k+ tests | Strict TypeScript, neostandard, API review, contract checks, and CI on every push. |
+| 4k+ tests, integration against real Postgres | Mocks drift; the driver doesn't lie. |
 
-## Current Status
-
-Valence is pre-1.0 and in active development. The schema engine, admin panel, REST API, GraphQL layer, telemetry pipeline, CLI, and Web Components are functional and tested. Recent work has focused on DB package hardening, stricter config/scaffold alignment, and tighter local-to-CI parity. Security hardening and API surface cleanup are still ongoing.
-
-See the [Architecture](ARCHITECTURE.md) doc for a detailed overview of the framework design.
+These constraints aren't ceremony. They're the reason a one-person team can hold the whole system in their head, and the reason errors surface where they happen instead of three layers away.
 
 ## Documentation
 
 - [Getting Started](GETTING-STARTED.md)
 - [Architecture](ARCHITECTURE.md)
+- [Stores & shared state](docs/STORES.md)
 - [CMS Guide](CMS-GUIDE.md)
 - [Developer Guide](DEVELOPER-GUIDE.md)
 - [Troubleshooting](TROUBLESHOOTING.md)

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valencets/cms",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valencets/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valencets/db",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -29,5 +29,6 @@
   ],
   "engines": {
     "node": ">=22"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/reactive/package.json
+++ b/packages/reactive/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@valencets/reactive",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
-  "description": "Zero-dependency signals layer for Valence admin UI — signal(), computed(), effect(), bind()",
+  "description": "Zero-dependency signals layer for Valence admin UI \u2014 signal(), computed(), effect(), bind()",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -1,0 +1,47 @@
+# @valencets/store
+
+Schema-driven shared state for [Valence](https://github.com/valencets/valence).
+One store definition — fields, mutations, derived values, an optional
+fragment — and the framework derives Zod validation on both sides, typed
+signals, per-mutation endpoints, an SSE channel, optimistic updates with
+server reconciliation, hydration, and declarative DOM binding.
+
+```ts
+import { field } from '@valencets/store'
+import type { StoreInput } from '@valencets/store'
+
+export const cart: StoreInput = {
+  slug: 'cart',
+  scope: 'session',      // page | session | user | global — who shares it
+  persist: true,         // survive restarts in postgres
+  fields: [field.array({ name: 'items', fields: [/* … */] })],
+  mutations: {
+    addItem: {
+      input: [field.text({ name: 'sku', required: true })],
+      server: async ({ state, input, pool }) => { /* server truth */ },
+      client: ({ state, input }) => { /* optional optimistic apply */ }
+    }
+  },
+  fragment: (state) => `<span>${(state.items as unknown[]).length}</span>`
+}
+```
+
+```html
+<section data-store="cart">
+  <fieldset data-commit="updateQuantity">
+    <input data-field="qty" type="number">
+  </fieldset>
+  <button data-mutation="addItem" data-args='{"sku":"abc"}'>Add</button>
+  <div data-fragment></div>
+</section>
+```
+
+The scope is the architecture: `page` never touches the server, `session`
+follows the visitor's tabs, `user` follows the account across devices,
+`global` is one shared copy for everyone — same client API throughout.
+Mutations carry intent, the server linearizes them, and the client rebases
+its pending queue on every authoritative response.
+
+Used through the `stores` array in `valence.config.ts`; see the
+[store documentation](https://github.com/valencets/valence/blob/master/docs/STORES.md)
+for the full contract.

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valencets/store",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Schema-driven shared state with server authority, optimistic mutations, and SSE reconciliation",
   "main": "dist/index.js",
@@ -34,7 +34,8 @@
     "vitest": "^4.0.18"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "license": "MIT",
   "repository": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valencets/telemetry",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valencets/ui",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/valence/package.json
+++ b/packages/valence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valencets/valence",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -25,9 +25,11 @@
     "@valencets/cms": "workspace:*",
     "@valencets/core": "workspace:*",
     "@valencets/db": "workspace:*",
+    "@valencets/reactive": "workspace:*",
     "@valencets/resultkit": "^0.5.0",
     "@valencets/store": "workspace:*",
     "@valencets/telemetry": "workspace:*",
+    "@valencets/ui": "workspace:*",
     "esbuild": "^0.27.0",
     "tsx": "^4.21.0",
     "zod": "^4.3.6"

--- a/packages/valence/src/__tests__/init-steps.test.ts
+++ b/packages/valence/src/__tests__/init-steps.test.ts
@@ -157,3 +157,41 @@ describe('createPromptQueue', () => {
     expect(await pending).toBe('typed-later')
   })
 })
+
+describe('scaffoldDependencies', () => {
+  it('installs the full platform pinned to the released versions', async () => {
+    const { scaffoldDependencies } = await import('../init-steps.js')
+    const deps = scaffoldDependencies('0.18.0', {
+      '@valencets/cms': '0.13.0',
+      '@valencets/core': '0.6.0',
+      '@valencets/db': '0.3.0',
+      '@valencets/store': '0.2.0',
+      '@valencets/reactive': '0.3.0',
+      '@valencets/ui': '0.4.0',
+      '@valencets/resultkit': '^0.5.0',
+      tsx: '^4.21.0'
+    })
+
+    expect(deps['@valencets/valence']).toBe('^0.18.0')
+    expect(deps['@valencets/cms']).toBe('^0.13.0')
+    expect(deps['@valencets/db']).toBe('^0.3.0')
+    expect(deps['@valencets/store']).toBe('^0.2.0')
+    expect(deps['@valencets/reactive']).toBe('^0.3.0')
+    expect(deps['@valencets/ui']).toBe('^0.4.0')
+    expect(deps['@valencets/resultkit']).toBe('^0.5.0')
+    expect(deps.tsx).toBe('^4.21.0')
+    expect(Object.values(deps)).not.toContain('latest')
+  })
+
+  it('falls back to latest only for unrewritten workspace links (monorepo dev)', async () => {
+    const { scaffoldDependencies } = await import('../init-steps.js')
+    const deps = scaffoldDependencies('0.18.0', {
+      '@valencets/cms': 'workspace:*',
+      '@valencets/store': 'workspace:*'
+    })
+
+    expect(deps['@valencets/cms']).toBe('latest')
+    expect(deps['@valencets/store']).toBe('latest')
+    expect(deps['@valencets/valence']).toBe('^0.18.0')
+  })
+})

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -14,7 +14,7 @@ import type { RestRouteEntry } from '@valencets/cms'
 import { readLearnProgress, writeLearnProgress, createInitialProgress } from './learn/index.js'
 import { log } from './cli-utils.js'
 import { generateConfigTemplate, generateSecret } from './config-template.js'
-import { parseInitFlags, askWithDefault, confirmWithDefault, createDbInvocations, migrationTargets, initSummary, createPromptQueue } from './init-steps.js'
+import { parseInitFlags, askWithDefault, confirmWithDefault, createDbInvocations, migrationTargets, initSummary, createPromptQueue, scaffoldDependencies } from './init-steps.js'
 import { landingPage } from './landing-page.js'
 import { loadEnvConfig, loadUserConfig, registerTsxLoader } from './config-loader.js'
 import type { RouteHandler } from './define-config.js'
@@ -154,8 +154,7 @@ async function runInit (args: ReadonlyArray<string>): Promise<void> {
   }
 
   const cliDir = dirname(fileURLToPath(import.meta.url))
-  const cliPkg = JSON.parse(readFileSync(join(cliDir, '..', 'package.json'), 'utf-8')) as { version: string }
-  const cliVersion = `^${cliPkg.version}`
+  const cliPkg = JSON.parse(readFileSync(join(cliDir, '..', 'package.json'), 'utf-8')) as { version: string, dependencies?: { [name: string]: string } }
 
   await writeFile(join(dir, 'package.json'), JSON.stringify({
     name: projectName,
@@ -169,10 +168,7 @@ async function runInit (args: ReadonlyArray<string>): Promise<void> {
       start: 'node dist/server.js'
     },
     dependencies: {
-      '@valencets/valence': cliVersion,
-      '@valencets/cms': 'latest',
-      '@valencets/db': 'latest',
-      tsx: '^4.21.0',
+      ...scaffoldDependencies(cliPkg.version, cliPkg.dependencies ?? {}),
       ...extraDeps
     },
     devDependencies: {

--- a/packages/valence/src/init-steps.ts
+++ b/packages/valence/src/init-steps.ts
@@ -193,3 +193,39 @@ export function createPromptQueue (input: LineSource, write: (prompt: string) =>
     }
   }
 }
+
+const PLATFORM_PACKAGES = [
+  '@valencets/cms',
+  '@valencets/db',
+  '@valencets/store',
+  '@valencets/reactive',
+  '@valencets/ui',
+  '@valencets/resultkit'
+] as const
+
+/**
+ * Scaffolded projects install the whole platform, pinned to the versions
+ * this CLI shipped with. The published package.json carries exact sibling
+ * versions (pnpm rewrites workspace links at publish), so the pins come
+ * from our own dependency map; unrewritten workspace links only occur in
+ * monorepo development, where `latest` is a harmless placeholder.
+ */
+export function scaffoldDependencies (
+  cliVersion: string,
+  ownDependencies: Readonly<{ [name: string]: string }>
+): { [name: string]: string } {
+  const pin = (declared: string | undefined): string => {
+    if (declared === undefined || declared.startsWith('workspace')) return 'latest'
+    if (declared.startsWith('^') || declared.startsWith('~')) return declared
+    return `^${declared}`
+  }
+
+  const deps: { [name: string]: string } = {
+    '@valencets/valence': `^${cliVersion}`
+  }
+  for (const name of PLATFORM_PACKAGES) {
+    deps[name] = pin(ownDependencies[name])
+  }
+  deps.tsx = pin(ownDependencies.tsx)
+  return deps
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       '@valencets/db':
         specifier: workspace:*
         version: link:../db
+      '@valencets/reactive':
+        specifier: workspace:*
+        version: link:../reactive
       '@valencets/resultkit':
         specifier: ^0.5.0
         version: 0.5.0
@@ -374,6 +377,9 @@ importers:
       '@valencets/telemetry':
         specifier: workspace:*
         version: link:../telemetry
+      '@valencets/ui':
+        specifier: workspace:*
+        version: link:../ui
       esbuild:
         specifier: ^0.27.0
         version: 0.27.4


### PR DESCRIPTION
Pre-release audit of "would an MVP built from the npm packages actually work?" found three blockers. All fixed here; this must merge to development before the release PR to master.

## Blockers fixed

1. **`@valencets/store` was missing from both the publish and release job lists** in ci.yml. The published `@valencets/valence` depends on it (pnpm rewrites `workspace:*` to the exact version at publish), so every `npm install` of the new valence would have failed on an unpublishable package. Store now publishes, ordered before valence.

2. **`valence init` scaffolds a project that can't build the app it implies.** The generated `package.json` installed only valence/cms/db (the latter two pinned to `latest`), but store definitions import `@valencets/store`, client entries import `@valencets/reactive` and `@valencets/ui`, and generated store modules import `@valencets/resultkit` types. The scaffold now installs the full platform, **pinned to the exact versions the CLI shipped with** — read from valence's own published dependency map, so app and framework stay in lockstep (`latest` survives only as the monorepo-dev fallback for unrewritten workspace links).

3. **Nothing would have published.** The publish job skips already-published versions and every changed package matched npm exactly. Bumps: valence **0.18.0**, store **0.2.0** (first publish), reactive **0.3.0**, ui **0.4.0**, cms **0.13.0**, db **0.3.0**, core **0.6.0**, telemetry **0.3.1**. graphql and the plugins are unchanged and stay put.

## Also in here

- `@valencets/valence` now depends on `@valencets/reactive` and `@valencets/ui` — the CLI is the platform package, and this is what makes lockstep pinning possible.
- npm-facing README for `@valencets/store` (its npm page was blank).
- `license: MIT` on the graphql package manifest.
- **Root README rewritten** around the framework's actual thesis — the schema-is-law premise, server-truth mutations, the browser-is-enough client story, and discipline-as-a-feature — with the store system and its declarative binding front and center, instead of a feature inventory that buried the point.

## Verification

- TDD pair for the scaffold pinning; 493 valence tests green.
- Full build + lint green.
- `check:tdd-sequence` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDPG7XK7hEnaanNWzJfo42)_