### PR TITLE
fix(security): resolve the CodeQL highs on the release PR — shell-free createdb, Secure cookies, inert fragment parsing

### DIFF
--- a/packages/store/src/client/fragment-reconciler.ts
+++ b/packages/store/src/client/fragment-reconciler.ts
@@ -4,9 +4,15 @@ interface FragmentEvent {
 }
 
 function parseFragment (html: string): DocumentFragment {
-  const template = document.createElement('template')
-  template.innerHTML = html
-  return template.content
+  // DOMParser builds an inert document: nothing executes during parsing,
+  // and the nodes only join the live document after sanitizeFragment has
+  // stripped scripts, handlers, and javascript: URLs.
+  const parsed = new DOMParser().parseFromString(html, 'text/html')
+  const fragment = document.createDocumentFragment()
+  for (const node of [...parsed.body.childNodes]) {
+    fragment.appendChild(document.importNode(node, true))
+  }
+  return fragment
 }
 
 /**

--- a/packages/valence/src/__tests__/init-steps.test.ts
+++ b/packages/valence/src/__tests__/init-steps.test.ts
@@ -85,11 +85,26 @@ describe('createDbInvocations', () => {
     })
 
     expect(invocations).toHaveLength(2)
-    expect(invocations[0]!.command).toBe('createdb -h db.internal -p 5433 -U app shop')
-    expect(invocations[1]!.command).toBe('createdb -h db.internal -p 5433 -U app shop_dev')
+    expect(invocations[0]!.file).toBe('createdb')
+    expect(invocations[0]!.args).toEqual(['-h', 'db.internal', '-p', '5433', '-U', 'app', 'shop'])
+    expect(invocations[1]!.args).toEqual(['-h', 'db.internal', '-p', '5433', '-U', 'app', 'shop_dev'])
     for (const invocation of invocations) {
       expect(invocation.env.PGPASSWORD).toBe('sekret')
     }
+  })
+
+  it('passes hostile answers as argv entries, never through a shell', () => {
+    const invocations = createDbInvocations({
+      dbName: 'x; rm -rf /', dbHost: '$(whoami)', dbPort: '5432', dbUser: 'a b', dbPassword: 'p'
+    })
+
+    // Argv arrays reach execFile verbatim — nothing is ever interpolated
+    // into a shell string, so metacharacters are inert data.
+    expect(invocations[0]!.args).toContain('x; rm -rf /')
+    expect(invocations[0]!.args).toContain('$(whoami)')
+    const flattened = [invocations[0]!.file, ...invocations[0]!.args].join(' ')
+    expect(invocations[0]!).not.toHaveProperty('command')
+    expect(flattened).toContain('$(whoami)')
   })
 })
 

--- a/packages/valence/src/__tests__/store-session.test.ts
+++ b/packages/valence/src/__tests__/store-session.test.ts
@@ -45,3 +45,18 @@ describe('signed store sessions', () => {
     expect(cookie).toContain('Path=/')
   })
 })
+
+describe('cookie security flags', () => {
+  it('marks the session cookie Secure on encrypted connections', async () => {
+    const { buildStoreSessionCookie } = await import('../store-session.js')
+    const cookie = buildStoreSessionCookie('abc.def', true)
+    expect(cookie).toContain('; Secure')
+    expect(cookie).toContain('HttpOnly')
+  })
+
+  it('omits Secure over plain http so local development keeps working', async () => {
+    const { buildStoreSessionCookie } = await import('../store-session.js')
+    const cookie = buildStoreSessionCookie('abc.def', false)
+    expect(cookie).not.toContain('Secure')
+  })
+})

--- a/packages/valence/src/__tests__/store-wiring.test.ts
+++ b/packages/valence/src/__tests__/store-wiring.test.ts
@@ -599,3 +599,26 @@ describe('hydrator surface for fragment pages and custom routes', () => {
     expect(await hydrator.readState('counter', pageReq(''), mockRes())).toBeNull()
   })
 })
+
+describe('cookie flags from the transport', () => {
+  const SECRET = 'wiring-test-secret'
+
+  it('mints Secure cookies over TLS and plain cookies over http', async () => {
+    const { registerRoute } = collectRoutes()
+    const hydrator = registerStoreRoutesOnServer([counterStore()], registerRoute, { secret: SECRET })
+
+    const tlsReq = Object.assign(new EventEmitter(), {
+      headers: {}, method: 'GET', socket: { encrypted: true }
+    }) as unknown as IncomingMessage
+    const tlsRes = mockRes()
+    await hydrator!(tlsReq, tlsRes, '<body><div data-store="counter"></div></body>')
+    expect(tlsRes._captured.headers['Set-Cookie']).toContain('; Secure')
+
+    const plainReq = Object.assign(new EventEmitter(), {
+      headers: {}, method: 'GET', socket: {}
+    }) as unknown as IncomingMessage
+    const plainRes = mockRes()
+    await hydrator!(plainReq, plainRes, '<body><div data-store="counter"></div></body>')
+    expect(plainRes._captured.headers['Set-Cookie']).not.toContain('Secure')
+  })
+})

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -3,7 +3,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createInterface } from 'node:readline/promises'
 import { stdin, stdout } from 'node:process'
-import { execSync } from 'node:child_process'
+import { execSync, execFileSync } from 'node:child_process'
 import { createServer } from 'node:http'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { ResultAsync, fromThrowable } from '@valencets/resultkit'
@@ -92,6 +92,18 @@ const safeExecSync = fromThrowable(
 
 function exec (cmd: string, cwd: string, env?: Readonly<{ [key: string]: string }>): boolean {
   return safeExecSync(cmd, cwd, env).isOk()
+}
+
+// No shell: user-supplied answers reach the binary as argv entries.
+const safeExecFileSync = fromThrowable(
+  (file: string, args: readonly string[], cwd: string, env: Readonly<{ [key: string]: string }>) => {
+    execFileSync(file, [...args], { cwd, stdio: 'pipe', env: { ...process.env, ...env } })
+  },
+  () => null
+)
+
+function execFile (file: string, args: readonly string[], cwd: string, env: Readonly<{ [key: string]: string }>): boolean {
+  return safeExecFileSync(file, args, cwd, env).isOk()
 }
 
 // -- init --
@@ -432,8 +444,8 @@ CREATE TABLE IF NOT EXISTS "store_states" (
     // Both databases up front: valence dev works on the _dev sibling,
     // valence start on the base — neither first run should trip.
     for (const invocation of createDbInvocations(dbAnswers)) {
-      log(`Creating database: ${invocation.command.split(' ').pop() ?? ''}...`)
-      if (exec(invocation.command, dir, invocation.env)) {
+      log(`Creating database: ${invocation.args[invocation.args.length - 1] ?? ''}...`)
+      if (execFile(invocation.file, invocation.args, dir, invocation.env)) {
         log('Database created.')
       } else {
         log('Warning: could not create it — it may already exist, or the connection details are wrong.')

--- a/packages/valence/src/init-steps.ts
+++ b/packages/valence/src/init-steps.ts
@@ -67,7 +67,8 @@ export interface DbConnectionAnswers {
 }
 
 export interface CommandInvocation {
-  readonly command: string
+  readonly file: string
+  readonly args: readonly string[]
   readonly env: Readonly<{ [key: string]: string }>
 }
 
@@ -75,14 +76,16 @@ export interface CommandInvocation {
  * `valence dev` works on `<name>_dev` and `valence start` on `<name>` —
  * init creates both so neither command's first run trips over a missing
  * database. Connection details come from the answers, not from whatever
- * OS user happens to be running init.
+ * OS user happens to be running init — and they travel as argv entries
+ * through execFile, never through a shell, so metacharacters in an
+ * answer are inert data instead of commands.
  */
 export function createDbInvocations (answers: DbConnectionAnswers): readonly CommandInvocation[] {
-  const flags = `-h ${answers.dbHost} -p ${answers.dbPort} -U ${answers.dbUser}`
+  const flags = ['-h', answers.dbHost, '-p', answers.dbPort, '-U', answers.dbUser]
   const env = Object.freeze({ PGPASSWORD: answers.dbPassword })
   return [
-    { command: `createdb ${flags} ${answers.dbName}`, env },
-    { command: `createdb ${flags} ${answers.dbName}_dev`, env }
+    { file: 'createdb', args: [...flags, answers.dbName], env },
+    { file: 'createdb', args: [...flags, `${answers.dbName}_dev`], env }
   ]
 }
 

--- a/packages/valence/src/store-session.ts
+++ b/packages/valence/src/store-session.ts
@@ -35,6 +35,9 @@ export function verifySignedSessionId (secret: string, token: string): string | 
   return id
 }
 
-export function buildStoreSessionCookie (token: string): string {
-  return `session_id=${token}; Path=/; HttpOnly; SameSite=Lax`
+export function buildStoreSessionCookie (token: string, secure = false): string {
+  // Secure mirrors the cms session cookie: derived from the transport, so
+  // TLS deployments never leak the token over plaintext while local http
+  // development keeps working.
+  return `session_id=${token}; Path=/; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`
 }

--- a/packages/valence/src/store-wiring.ts
+++ b/packages/valence/src/store-wiring.ts
@@ -107,7 +107,8 @@ async function resolveIdentity (
   }
 
   const minted = mintSignedSessionId(secret)
-  res.setHeader('Set-Cookie', buildStoreSessionCookie(minted))
+  const secureTransport = !!((req.socket as { encrypted?: boolean } | undefined)?.encrypted)
+  res.setHeader('Set-Cookie', buildStoreSessionCookie(minted, secureTransport))
   const dot = minted.indexOf('.')
   return { id: minted.slice(0, dot) }
 }


### PR DESCRIPTION
CodeQL flagged two new high-severity alerts on the release PR (#327). The release diff is everything since master, so I hardened all three high-severity patterns that exist in that new code rather than guessing which two fired:

1. **Shell command built from user answers** (`valence init`). `createdb -h ${host} … ${name}` interpolated interactive answers into a shell string executed by `execSync`. `createDbInvocations` now returns `{ file, args, env }` and the CLI runs them through `execFileSync` — answers reach the binary as argv entries, so a database name like `x; rm -rf /` is inert data. The RED test feeds hostile answers and asserts they stay argv.

2. **Session cookie without `Secure`** (store wiring). The signed anonymous `session_id` cookie is now marked `Secure` when minted over TLS, derived from `req.socket.encrypted` exactly like the cms session cookie — TLS deployments never leak the token over plaintext, local http development keeps working. Tested both transports.

3. **`innerHTML` parse sink** (fragment reconciler). Fragments were parsed via `template.innerHTML = html` before sanitization. Parsing now goes through `DOMParser` into an inert document; nodes are imported into the live document only after `sanitizeFragment` strips scripts, `on*` handlers, and `javascript:` URLs. Identical behavior — all 365 store tests pass unchanged, including the XSS suite.

Gate: build, lint, patterns, api baselines green; 497 valence + 365 store tests. Once merged, #327 re-runs CodeQL against the updated development head.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDPG7XK7hEnaanNWzJfo42)_