### PR TITLE
chore(security): make the traversal barrier visible to taint tracking; env-hoist workflow contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,24 +236,33 @@ jobs:
         with:
           fetch-depth: 0
       - name: Validate TDD commit sequence
+        env:
+          # Contexts reach the script as environment data, never by string
+          # interpolation into bash — a branch named `x"; cmd; "` stays a
+          # branch name instead of becoming code.
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             # The checkout above is fetch-depth: 0 — a --depth=1 fetch here
             # would shallow the base ref and corrupt merge-base resolution,
             # making the check sweep unrelated history after base moves.
-            git fetch origin "${{ github.base_ref }}"
-            BASE="$(git merge-base HEAD "origin/${{ github.base_ref }}" || true)"
+            git fetch origin "$BASE_REF"
+            BASE="$(git merge-base HEAD "origin/$BASE_REF" || true)"
             if [ -z "$BASE" ]; then
-              echo "No merge base with origin/${{ github.base_ref }} — cannot scope the range" >&2
+              echo "No merge base with origin/$BASE_REF — cannot scope the range" >&2
               exit 1
             fi
-            if [ "${{ github.base_ref }}" = "master" ] && [ "${{ github.head_ref }}" = "development" ]; then
+            if [ "$BASE_REF" = "master" ] && [ "$HEAD_REF" = "development" ]; then
               TDD_SEQUENCE_START=f3aae193 bash scripts/check-tdd-commit-sequence.sh range "$BASE..HEAD"
             else
               bash scripts/check-tdd-commit-sequence.sh range "$BASE..HEAD"
             fi
-          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            bash scripts/check-tdd-commit-sequence.sh range "${{ github.event.before }}..${{ github.sha }}"
+          elif [ "$EVENT_BEFORE" != "0000000000000000000000000000000000000000" ]; then
+            bash scripts/check-tdd-commit-sequence.sh range "$EVENT_BEFORE..$HEAD_SHA"
           elif git rev-parse HEAD^ >/dev/null 2>&1; then
             bash scripts/check-tdd-commit-sequence.sh range "HEAD^..HEAD"
           fi

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -1,5 +1,5 @@
 import { writeFile, mkdir } from 'node:fs/promises'
-import { join, dirname } from 'node:path'
+import { join, dirname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createInterface } from 'node:readline/promises'
 import { stdin, stdout } from 'node:process'
@@ -740,8 +740,13 @@ async function runDev (): Promise<void> {
     const publicDir = join(projectDir, 'public')
     const staticResult = resolveStaticPath(pathname, publicDir)
     if (staticResult.isOk()) {
-      const filePath = staticResult.value
-      if (existsSync(filePath) && statSync(filePath).isFile()) {
+      // The resolver already guarantees containment; re-asserting the
+      // resolve + startsWith barrier here keeps the guard visible on this
+      // exact dataflow path from req.url to the filesystem.
+      const publicRoot = resolve(publicDir)
+      const filePath = resolve(staticResult.value)
+      const contained = filePath === publicRoot || filePath.startsWith(publicRoot + sep)
+      if (contained && existsSync(filePath) && statSync(filePath).isFile()) {
         const mime = resolveMimeType(filePath)
         const rangeHeader = typeof req.headers['range'] === 'string' ? req.headers['range'] : undefined
         await serveStaticFile(filePath, mime, rangeHeader, res)
@@ -1009,8 +1014,13 @@ export async function runStart (): Promise<void> {
     const publicDir = join(projectDir, 'public')
     const staticResult = resolveStaticPath(pathname, publicDir)
     if (staticResult.isOk()) {
-      const filePath = staticResult.value
-      if (existsSync(filePath) && statSync(filePath).isFile()) {
+      // The resolver already guarantees containment; re-asserting the
+      // resolve + startsWith barrier here keeps the guard visible on this
+      // exact dataflow path from req.url to the filesystem.
+      const publicRoot = resolve(publicDir)
+      const filePath = resolve(staticResult.value)
+      const contained = filePath === publicRoot || filePath.startsWith(publicRoot + sep)
+      if (contained && existsSync(filePath) && statSync(filePath).isFile()) {
         const mime = resolveMimeType(filePath)
         const rangeHeader = typeof req.headers['range'] === 'string' ? req.headers['range'] : undefined
         await serveStaticFile(filePath, mime, rangeHeader, res)


### PR DESCRIPTION
Second pass at the two CodeQL highs on #327 — this time triangulated instead of guessed.

## Why the first pass missed

The check reports the **high** bucket (security-severity 7.0–8.9), which *excludes* the critical-band injection patterns #328 fixed. Cross-referencing every default-suite high-band query against the actual release diff leaves one pattern with **exactly two locations**, both inside code this PR changed and both untouched by #328: `js/path-injection` (7.5) on the two static-file-serving handlers in `cli.ts` — dev and start.

The flow is `req.url → pathname → resolveStaticPath → serveStaticFile → createReadStream`. `resolveStaticPath` already implements the canonical defense (decode, normalize, then `resolve` + `startsWith(root)`), so the code is not actually vulnerable — but the guard lives inside a Result-returning helper, and taint tracking doesn't credit sanitizers it can't see on the sink's own dataflow path.

## The fix

- **Re-assert the barrier at both sinks**: `resolve(publicDir)` / `resolve(filePath)` / `startsWith(root + sep)` inline before `serveStaticFile`, in both the dev and start handlers. Redundant by construction, free at runtime, and it's the exact guard pattern the analyzer recognizes.
- **While in the neighborhood**: the TDD-history workflow step interpolated `${{ github.head_ref }}` (attacker-controlled on fork PRs) and other contexts directly into its `run:` script. All contexts now reach bash as `env:` variables — data, never code. Real hardening regardless of which bucket the scanner files it under.

497 valence tests, build and lint green. If the re-run against this still reports 2 highs, the next step is zero guesswork: open the [alert list for the PR](https://github.com/valencets/valence/security/code-scanning?query=pr%3A327+tool%3ACodeQL+is%3Aopen) and read the two rule names — that page needs repo-admin eyes, which I don't have from here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDPG7XK7hEnaanNWzJfo42)_