### PR TITLE
fix(valence): enforce CMS_SECRET at production start (#339)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -124,3 +124,19 @@ This ensures the component is registered exactly once per test file.
 1. Ensure `pnpm-workspace.yaml` contains `packages: ["packages/*"]`
 2. Ensure each package's `package.json` uses `"workspace:*"` for internal dependencies
 3. Run `pnpm install` from the repository root, not from inside a package directory
+
+## `valence start` refuses to boot: CMS_SECRET error
+
+**Symptom**: Production start exits with `Error: CMS_SECRET must be set…`, `…is the known default…`, or `…must be at least 32 characters…`.
+
+**Cause**: `CMS_SECRET` signs anonymous store sessions (HMAC-SHA256) and underpins session security. Production refuses to run with a missing, default (`dev-secret`, `change-me`), or short secret — a forgeable secret means forgeable sessions.
+
+**Fix**: Mint a real secret and put it in `.env`:
+
+```bash
+node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"
+```
+
+`valence init` already writes a CSPRNG-minted secret into the scaffolded `.env`; the `.env.example` placeholder `change-me` is rejected by design so it can never be promoted to production unchanged.
+
+**Rotation semantics**: rotating `CMS_SECRET` invalidates every signed anonymous store session immediately — anonymous visitors get fresh (empty) session-scoped store buckets on next contact. This is by design: signed anonymous sessions are stateless and cannot be revoked individually (see `docs/STORES.md`). Authenticated `cms_session` logins are stored server-side and survive rotation. Rotate during a low-traffic window if anonymous carts/drafts matter to you.

--- a/packages/valence/src/__tests__/cli-start.test.ts
+++ b/packages/valence/src/__tests__/cli-start.test.ts
@@ -56,4 +56,74 @@ describe('runStart CMS_SECRET guard', () => {
     expect(exitCode).toBe(1)
     expect(errors.some((e) => e.includes('CMS_SECRET'))).toBe(true)
   })
+
+  it('exits with code 1 when CMS_SECRET is the dev fallback "dev-secret"', async () => {
+    process.env.CMS_SECRET = 'dev-secret'
+    const errors: string[] = []
+    const originalError = console.error
+    console.error = (...args: string[]) => { errors.push(args.join(' ')) }
+
+    const { runStart } = await import('../cli.js')
+
+    let exitCode: number | undefined
+    try {
+      await runStart()
+    } catch (err) {
+      if (err instanceof ExitError) {
+        exitCode = err.code
+      }
+    }
+
+    console.error = originalError
+
+    expect(exitCode).toBe(1)
+    expect(errors.some((e) => e.includes('CMS_SECRET'))).toBe(true)
+  })
+
+  it('exits with code 1 when CMS_SECRET is shorter than 32 characters', async () => {
+    process.env.CMS_SECRET = 'too-short-to-sign-anything'
+    const errors: string[] = []
+    const originalError = console.error
+    console.error = (...args: string[]) => { errors.push(args.join(' ')) }
+
+    const { runStart } = await import('../cli.js')
+
+    let exitCode: number | undefined
+    try {
+      await runStart()
+    } catch (err) {
+      if (err instanceof ExitError) {
+        exitCode = err.code
+      }
+    }
+
+    console.error = originalError
+
+    expect(exitCode).toBe(1)
+    expect(errors.some((e) => e.includes('CMS_SECRET'))).toBe(true)
+  })
+
+  it('boots past the secret guard with a strong secret (fails later on config, not CMS_SECRET)', async () => {
+    process.env.CMS_SECRET = 'f'.repeat(64)
+    const errors: string[] = []
+    const originalError = console.error
+    console.error = (...args: string[]) => { errors.push(args.join(' ')) }
+
+    const { runStart } = await import('../cli.js')
+
+    let exitCode: number | undefined
+    try {
+      await runStart()
+    } catch (err) {
+      if (err instanceof ExitError) {
+        exitCode = err.code
+      }
+    }
+
+    console.error = originalError
+
+    expect(exitCode).toBe(1)
+    expect(errors.some((e) => e.includes('CMS_SECRET'))).toBe(false)
+    expect(errors.some((e) => e.includes('valence.config.ts'))).toBe(true)
+  })
 })

--- a/packages/valence/src/__tests__/secret-guard.test.ts
+++ b/packages/valence/src/__tests__/secret-guard.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { validateProductionSecret, MIN_SECRET_LENGTH, SecretErrorCode } from '../secret-guard.js'
+import { generateSecret } from '../config-template.js'
+
+// #339 — production must never run with a missing, default, or trivially
+// weak CMS_SECRET: it signs anonymous store sessions (HMAC) and underpins
+// session security.
+
+describe('validateProductionSecret', () => {
+  it('rejects a missing secret', () => {
+    const result = validateProductionSecret(undefined)
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.code).toBe(SecretErrorCode.MISSING)
+      expect(result.error.message).toContain('CMS_SECRET')
+    }
+  })
+
+  it('rejects an empty secret', () => {
+    const result = validateProductionSecret('')
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.code).toBe(SecretErrorCode.MISSING)
+    }
+  })
+
+  it('rejects the dev fallback "dev-secret"', () => {
+    const result = validateProductionSecret('dev-secret')
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.code).toBe(SecretErrorCode.KNOWN_DEFAULT)
+      expect(result.error.message).toContain('CMS_SECRET')
+    }
+  })
+
+  it('rejects the .env.example placeholder "change-me"', () => {
+    const result = validateProductionSecret('change-me')
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.code).toBe(SecretErrorCode.KNOWN_DEFAULT)
+    }
+  })
+
+  it(`rejects secrets shorter than ${MIN_SECRET_LENGTH} characters`, () => {
+    const result = validateProductionSecret('a'.repeat(MIN_SECRET_LENGTH - 1))
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.code).toBe(SecretErrorCode.TOO_SHORT)
+      expect(result.error.message).toContain(String(MIN_SECRET_LENGTH))
+    }
+  })
+
+  it(`accepts a secret of exactly ${MIN_SECRET_LENGTH} characters`, () => {
+    const result = validateProductionSecret('x'.repeat(MIN_SECRET_LENGTH))
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value).toBe('x'.repeat(MIN_SECRET_LENGTH))
+    }
+  })
+})
+
+describe('generateSecret', () => {
+  it('mints secrets that pass the production guard', () => {
+    const result = validateProductionSecret(generateSecret())
+    expect(result.isOk()).toBe(true)
+  })
+
+  it('emits 64 lowercase hex characters (32 bytes of CSPRNG output)', () => {
+    const secret = generateSecret()
+    expect(secret).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('emits a different secret on every call', () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 16; i++) {
+      seen.add(generateSecret())
+    }
+    expect(seen.size).toBe(16)
+  })
+})

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -14,6 +14,7 @@ import type { RestRouteEntry } from '@valencets/cms'
 import { readLearnProgress, writeLearnProgress, createInitialProgress } from './learn/index.js'
 import { log } from './cli-utils.js'
 import { generateConfigTemplate, generateSecret } from './config-template.js'
+import { validateProductionSecret } from './secret-guard.js'
 import { parseInitFlags, askWithDefault, confirmWithDefault, createDbInvocations, migrationTargets, initSummary, createPromptQueue, scaffoldDependencies } from './init-steps.js'
 import { landingPage } from './landing-page.js'
 import { loadEnvConfig, loadUserConfig, registerTsxLoader } from './config-loader.js'
@@ -884,11 +885,14 @@ export async function runStart (): Promise<void> {
     process.exit(1)
   }
 
-  const cmsSecret = process.env.CMS_SECRET
-  if (!cmsSecret) {
-    console.error('  Error: CMS_SECRET must be set in .env for production.')
+  // #339 — the secret signs anonymous store sessions; missing, default,
+  // or short values must refuse to boot rather than run forgeable.
+  const secretResult = validateProductionSecret(process.env.CMS_SECRET)
+  if (secretResult.isErr()) {
+    console.error(`  Error: ${secretResult.error.message}`)
     process.exit(1)
   }
+  const cmsSecret = secretResult.value
 
   const projectDir = process.cwd()
 

--- a/packages/valence/src/config-template.ts
+++ b/packages/valence/src/config-template.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto'
+
 export interface ConfigTemplateOptions {
   readonly dbName: string
   readonly dbUser: string
@@ -91,11 +93,11 @@ export default defineConfig({
 `
 }
 
+/**
+ * Mint a CMS_SECRET for the scaffolded .env — 32 bytes of CSPRNG output as
+ * 64 hex chars. Math.random is banned here: the secret keys the HMAC that
+ * signs anonymous store sessions, so it must be unpredictable.
+ */
 export function generateSecret (): string {
-  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789'
-  let result = ''
-  for (let i = 0; i < 32; i++) {
-    result += chars[Math.floor(Math.random() * chars.length)]
-  }
-  return result
+  return randomBytes(32).toString('hex')
 }

--- a/packages/valence/src/secret-guard.ts
+++ b/packages/valence/src/secret-guard.ts
@@ -1,0 +1,56 @@
+import { ok, err } from '@valencets/resultkit'
+import type { Result } from '@valencets/resultkit'
+
+/**
+ * Production gate for CMS_SECRET (#339). The secret signs anonymous store
+ * sessions (HMAC-SHA256) and underpins session security — a missing,
+ * default, or trivially short value must refuse to boot rather than run
+ * silently forgeable.
+ */
+
+export const SecretErrorCode = Object.freeze({
+  MISSING: 'MISSING',
+  KNOWN_DEFAULT: 'KNOWN_DEFAULT',
+  TOO_SHORT: 'TOO_SHORT'
+} as const)
+
+export type SecretErrorCode = typeof SecretErrorCode[keyof typeof SecretErrorCode]
+
+export interface SecretError {
+  readonly code: SecretErrorCode
+  readonly message: string
+}
+
+export const MIN_SECRET_LENGTH = 32
+
+// Values the framework itself has ever suggested: the runDev fallback and
+// the .env.example placeholder. Both are public knowledge — running
+// production with either means every signed session is forgeable.
+const KNOWN_DEFAULTS: ReadonlySet<string> = Object.freeze(new Set(['dev-secret', 'change-me']))
+
+const REGENERATE_HINT = 'Generate one with: node -e "console.log(require(\'node:crypto\').randomBytes(32).toString(\'hex\'))"'
+
+export function validateProductionSecret (secret: string | undefined): Result<string, SecretError> {
+  if (secret === undefined || secret === '') {
+    return err({
+      code: SecretErrorCode.MISSING,
+      message: `CMS_SECRET must be set in .env for production. ${REGENERATE_HINT}`
+    })
+  }
+
+  if (KNOWN_DEFAULTS.has(secret)) {
+    return err({
+      code: SecretErrorCode.KNOWN_DEFAULT,
+      message: `CMS_SECRET is the known default "${secret}" — production requires a unique secret. ${REGENERATE_HINT}`
+    })
+  }
+
+  if (secret.length < MIN_SECRET_LENGTH) {
+    return err({
+      code: SecretErrorCode.TOO_SHORT,
+      message: `CMS_SECRET must be at least ${MIN_SECRET_LENGTH} characters, got ${secret.length}. ${REGENERATE_HINT}`
+    })
+  }
+
+  return ok(secret)
+}


### PR DESCRIPTION
Closes #339.

## What

`valence start` previously refused to boot only when `CMS_SECRET` was entirely absent. It now refuses missing, **known-default** (`dev-secret`, `change-me`), and **short** (< 32 chars) secrets with actionable error messages — the secret keys the HMAC that signs anonymous store sessions, so a weak value means forgeable sessions.

Also fixes an audit finding folded into this issue: `generateSecret()` (the `valence init` `.env` minter) used `Math.random()` — a predictable PRNG — to mint the HMAC key. It now emits 32 bytes of `crypto.randomBytes` as 64 hex chars.

## Changes

- **`secret-guard.ts` (new)**: `validateProductionSecret(secret): Result<string, SecretError>` — frozen const error union (`MISSING` / `KNOWN_DEFAULT` / `TOO_SHORT`), `MIN_SECRET_LENGTH = 32`, regeneration hint in every message
- **`cli.ts`**: `runStart` boots through the guard; `runDev` keeps its `dev-secret` fallback (dev ergonomics, per the issue)
- **`config-template.ts`**: `generateSecret()` → CSPRNG (64-char hex; existing 32-char secrets from older scaffolds still pass the guard)
- **`docs/TROUBLESHOOTING.md`**: boot-refusal symptoms + rotation semantics (rotation invalidates all signed anonymous store sessions by design; `cms_session` logins survive)

## Validation

- TDD: RED (module-missing + 2 failing runStart guard tests) → GREEN → REFACTOR; sequence check passes
- 13 new/updated tests green: pure guard matrix (missing/empty/dev-secret/change-me/31-char/32-char), `generateSecret` strength + uniqueness + guard-passthrough, and `runStart` exit-code tests incl. a strong-secret passthrough asserting the failure moves past the secret check
- `.env.example` keeps `CMS_SECRET=change-me` deliberately — the guard now makes it impossible to promote unchanged
- tsc, eslint, banned-patterns green; `valence.api.md` unchanged (guard is internal, surface freeze is #337)