### PR TITLE
security(store): Origin checking on /store/* mutation POSTs (#340)

### DIFF
--- a/docs/STORES.md
+++ b/docs/STORES.md
@@ -258,7 +258,8 @@ next file change) and the last good bundle keeps serving.
 Per store (except `page` scope):
 
 - `POST /store/:slug/:mutation` — body `{ args, mutationId }`; 400 on
-  validation failure, 404 on unknown mutation, 413 over 256 KB.
+  validation failure, 403 when a declared `Origin`/`Referer` does not match
+  the request host, 404 on unknown mutation, 413 over 256 KB.
 - `GET /store/:slug/state` — current state as JSON.
 - `GET /store/:slug/events` — SSE channel (heartbeat every 30 s; one
   session may hold many tabs).
@@ -317,6 +318,13 @@ user-scoped store and a database pool are configured.
 - Anonymous session ids are HMAC-signed and verified timing-safely;
   authenticated identity is validated against the CMS sessions table with
   its expiry and soft-delete checks.
+- Mutation POSTs carry Origin defense in depth on top of `SameSite=Lax`
+  cookies: a declared `Origin` (or `Referer` when no Origin is present)
+  whose host differs from the request host — including the opaque `null`
+  origin — is rejected with 403 before identity resolution, so rejected
+  requests never mint session cookies. Requests declaring neither header
+  (curl, server-to-server) pass: they carry no ambient browser credentials
+  to launder.
 - The per-bucket mutation lock is in-process. Multi-process or multi-node
   deployments sharing one database need row-level locking on
   `store_states` before serving the same user-scoped store from several

--- a/packages/valence/src/__tests__/store-wiring.test.ts
+++ b/packages/valence/src/__tests__/store-wiring.test.ts
@@ -14,10 +14,10 @@ interface CapturedResponse {
   written: string[]
 }
 
-function mockReq (options?: { cookie?: string; body?: string }): IncomingMessage {
+function mockReq (options?: { cookie?: string; body?: string; headers?: { [key: string]: string } }): IncomingMessage {
   const emitter = new EventEmitter()
   const req = Object.assign(emitter, {
-    headers: { cookie: options?.cookie ?? 'session_id=sess-a' },
+    headers: { cookie: options?.cookie ?? 'session_id=sess-a', ...(options?.headers ?? {}) },
     method: 'POST'
   })
   if (options?.body !== undefined) {
@@ -81,10 +81,11 @@ async function postMutation (
   slug: string,
   mutation: string,
   body: string,
-  cookie?: string
+  cookie?: string,
+  headers?: { [key: string]: string }
 ): Promise<CapturedResponse> {
   const handler = routes.get(`POST /store/${slug}/:mutation`)!
-  const req = mockReq({ body, ...(cookie !== undefined ? { cookie } : {}) })
+  const req = mockReq({ body, ...(cookie !== undefined ? { cookie } : {}), ...(headers !== undefined ? { headers } : {}) })
   const res = mockRes()
   await handler(req, res, { mutation })
   return res._captured
@@ -653,5 +654,119 @@ describe('cookie flags from the transport', () => {
     const plainRes = mockRes()
     await hydrator!(plainReq, plainRes, '<body><div data-store="counter"></div></body>')
     expect(plainRes._captured.headers['Set-Cookie']).not.toContain('Secure')
+  })
+})
+
+// #340 — cookie-authenticated mutation POSTs get Origin defense in depth:
+// a declared browser origin that does not match the request host is
+// rejected before identity resolution. Requests declaring no origin at all
+// (curl, server-to-server) pass — they carry no ambient browser
+// credentials to launder.
+describe('cross-origin mutation rejection', () => {
+  const HOST = 'localhost:3000'
+
+  async function getState (
+    routes: Map<string, RouteHandler>,
+    slug: string,
+    cookie: string,
+    headers?: { [key: string]: string }
+  ): Promise<CapturedResponse> {
+    const handler = routes.get(`GET /store/${slug}/state`)!
+    const emitter = new EventEmitter()
+    const req = Object.assign(emitter, {
+      headers: { cookie, ...(headers ?? {}) },
+      method: 'GET'
+    }) as unknown as IncomingMessage
+    const res = mockRes()
+    await handler(req, res, {})
+    return res._captured
+  }
+
+  it('rejects a POST whose Origin does not match the request host', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore()], registerRoute)
+
+    const captured = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":5}}', undefined,
+      { host: HOST, origin: 'https://evil.example' })
+
+    expect(captured.statusCode).toBe(403)
+
+    // The rejected mutation must not have touched state
+    const state = await getState(routes, 'counter', 'session_id=sess-a')
+    expect(JSON.parse(state.body).count).toBe(0)
+  })
+
+  it('rejects a POST whose Referer (no Origin) does not match the request host', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore()], registerRoute)
+
+    const captured = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":5}}', undefined,
+      { host: HOST, referer: 'https://evil.example/attack-page' })
+
+    expect(captured.statusCode).toBe(403)
+  })
+
+  it('rejects a POST with an opaque "null" Origin', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore()], registerRoute)
+
+    const captured = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":5}}', undefined,
+      { host: HOST, origin: 'null' })
+
+    expect(captured.statusCode).toBe(403)
+  })
+
+  it('allows a same-origin POST (Origin host matches the Host header)', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore()], registerRoute)
+
+    const captured = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":2}}', undefined,
+      { host: HOST, origin: `http://${HOST}` })
+
+    expect(captured.statusCode).toBe(200)
+    expect(JSON.parse(captured.body).state.count).toBe(2)
+  })
+
+  it('allows a same-origin POST identified via Referer', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore()], registerRoute)
+
+    const captured = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":3}}', undefined,
+      { host: HOST, referer: `http://${HOST}/cart` })
+
+    expect(captured.statusCode).toBe(200)
+    expect(JSON.parse(captured.body).state.count).toBe(3)
+  })
+
+  it('allows a POST declaring neither Origin nor Referer (curl / server-to-server)', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore()], registerRoute)
+
+    const captured = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":1}}', undefined,
+      { host: HOST })
+
+    expect(captured.statusCode).toBe(200)
+  })
+
+  it('leaves GET /state untouched by foreign Origins', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore()], registerRoute)
+
+    const state = await getState(routes, 'counter', 'session_id=sess-a',
+      { host: HOST, origin: 'https://evil.example' })
+
+    expect(state.statusCode).toBe(200)
+  })
+
+  it('rejects cross-origin requests before minting any session cookie', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    registerStoreRoutesOnServer([counterStore()], registerRoute, { secret: 'wiring-test-secret' })
+
+    const captured = await postMutation(routes, 'counter', 'increment', '{"args":{"amount":1}}', '',
+      { host: HOST, origin: 'https://evil.example' })
+
+    expect(captured.statusCode).toBe(403)
+    expect(captured.headers['Set-Cookie']).toBeUndefined()
+    expect(captured.headers['set-cookie']).toBeUndefined()
   })
 })

--- a/packages/valence/src/store-wiring.ts
+++ b/packages/valence/src/store-wiring.ts
@@ -127,6 +127,34 @@ function rejectAnonymous (res: ServerResponse): void {
   sendJson(res, 403, { error: { code: 'FORBIDDEN', message: 'User-scoped stores require an authenticated session' } })
 }
 
+const safeParseUrl = fromThrowable((value: string) => new URL(value), () => null)
+
+/**
+ * Origin defense in depth for cookie-authenticated mutation POSTs (#340).
+ * SameSite=Lax already blocks most cross-site POSTs; this rejects the rest
+ * whenever the browser declares a foreign origin — including the opaque
+ * "null" origin from sandboxed frames. Requests declaring neither Origin
+ * nor Referer (curl, server-to-server) pass: they carry no ambient browser
+ * credentials to launder. Runs before identity resolution so rejected
+ * requests never mint session cookies.
+ */
+function rejectsCrossOrigin (req: IncomingMessage, res: ServerResponse): boolean {
+  const origin = req.headers.origin
+  const referer = req.headers.referer
+  const declared = (typeof origin === 'string' && origin !== '')
+    ? origin
+    : (typeof referer === 'string' && referer !== '') ? referer : null
+  if (declared === null) return false
+
+  const host = req.headers.host
+  const parsed = safeParseUrl(declared)
+  const declaredHost = (parsed.isOk() && parsed.value !== null) ? parsed.value.host : null
+  if (host !== undefined && declaredHost !== null && declaredHost === host) return false
+
+  sendJson(res, 403, { error: { code: 'FORBIDDEN', message: 'Cross-origin request rejected' } })
+  return true
+}
+
 const ERROR_STATUS: Readonly<Record<string, number>> = Object.freeze({
   VALIDATION_FAILED: 400,
   INVALID_MUTATION: 404,
@@ -225,6 +253,7 @@ export function registerStoreRoutesOnServer (
 
     // POST /store/:slug/:mutation — execute mutation
     registerRoute('POST', `/store/${config.slug}/:mutation`, async (req: IncomingMessage, res: ServerResponse, params: Record<string, string>) => {
+      if (rejectsCrossOrigin(req, res)) return
       const identity = await requireIdentity(req, res)
       if (identity === null) return
       const mutationName = params.mutation ?? ''


### PR DESCRIPTION
Closes #340.

## What

Store mutation endpoints are cookie-authenticated; `SameSite=Lax` blocks most cross-site POSTs but 1.0 wants defense in depth. `POST /store/:slug/:mutation` now rejects any request whose declared browser origin does not match the request host — before identity resolution.

## Semantics (as the issue asked to be decided + documented)

| Request | Result |
|---|---|
| `Origin` host ≠ `Host` | **403**, no body read, no state touched |
| No `Origin`, `Referer` host ≠ `Host` | **403** |
| Opaque `Origin: null` (sandboxed frames) | **403** |
| `Origin`/`Referer` host = `Host` | pass |
| Neither header declared (curl, server-to-server) | pass — no ambient browser credentials to launder |
| GET endpoints (`/state`, `/events`, `/hydration`) | untouched — safe methods |

The check runs **before** `resolveIdentity`, so rejected cross-origin requests never mint anonymous session cookies (asserted in tests).

## Why not `core`'s `createOriginCheck` middleware

The existing core middleware is allowlist-configured and rejects no-Origin requests — wrong semantics for this surface (the issue explicitly wants curl/CLI documented as passing). The store check is host-derived, needs no config, and lives at the route registration point in `store-wiring.ts` so it holds regardless of which server mounts the routes. Admin POSTs already carry CSRF tokens; extending origin checking there is noted in #340 as a consideration and can ride the cookie-abstraction work (#342).

## Validation

- TDD: RED (4 failing rejection tests; allow-paths pre-verified) → GREEN → REFACTOR; sequence check passes
- 8 new tests in `store-wiring.test.ts` covering the whole matrix above; 43/43 in the file, 371/371 in `@valencets/store`
- `docs/STORES.md`: endpoint status list + security model updated
- tsc, eslint, banned-patterns green