### PR TITLE
fix(cms): wire the dead lifecycle hooks — collection beforeChange/afterChange/afterRead, field beforeValidate (#335)

### DIFF
--- a/packages/cms/docs/guide.md
+++ b/packages/cms/docs/guide.md
@@ -426,6 +426,42 @@ const cms = buildCms({
 
 Hooks run at specific lifecycle points during CRUD operations. They execute sequentially and can transform data.
 
+### Definitive firing order
+
+Every entry path (REST, Local API, admin, GraphQL, bulk operations) delegates to the Local API, so one order holds everywhere:
+
+**Writes (create / update):**
+
+```
+beforeValidate (collection)   ─ may transform data, runs before the transaction
+beforeValidate (field)
+┌─ transaction begins ─────────────────────────────────────┐
+beforeChange (collection)     ─ may transform data
+beforeChange (field)
+[beforePublish (collection)]  ─ publish updates only
+INSERT / UPDATE
+[afterPublish (collection)]   ─ publish updates only
+afterChange (field)           ─ may transform the returned document
+afterChange (collection)      ─ side effects only; return value ignored
+└─ transaction commits ────────────────────────────────────┘
+```
+
+A hook that throws inside the transaction rolls the write back — no partial state survives.
+
+**Reads (find / findByID):**
+
+```
+beforeRead (collection)       ─ runs before the query
+SELECT
+afterRead (field)             ─ per document, may transform
+afterRead (collection)        ─ per document, may transform
+field-level access filtering  ─ protected fields removed last
+```
+
+**Deletes:** `beforeDelete → DELETE → afterDelete`. **Unpublish:** `beforeUnpublish → UPDATE → afterUnpublish`.
+
+Known limitation: localized-merge updates (`update` with a `locale` on a collection with localized fields) currently bypass change hooks — the jsonb merge semantics predate the hook wiring. Tracked with the transactional-integrity work in #334.
+
 ### Auto-generating slugs
 
 ```typescript

--- a/packages/cms/src/__tests__/lifecycle-hooks-matrix.test.ts
+++ b/packages/cms/src/__tests__/lifecycle-hooks-matrix.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createLocalApi } from '../api/local-api.js'
+import { createCollectionRegistry, createGlobalRegistry } from '../schema/registry.js'
+import { collection } from '../schema/collection.js'
+import { field } from '../schema/fields.js'
+import { makeMockPool } from './test-helpers.js'
+import type { HookArgs, HookFunction, CollectionHooks } from '../hooks/hook-types.js'
+import type { FieldConfig } from '../schema/field-types.js'
+
+// #335 — every advertised lifecycle hook must actually fire, in a defined
+// order. The canonical write order is:
+//   beforeValidate(col) → beforeValidate(field) → beforeChange(col) →
+//   beforeChange(field) → write → afterChange(field) → afterChange(col)
+// publish updates nest the write in beforePublish → write → afterPublish.
+// The canonical read order is:
+//   beforeRead(col) → query → afterRead(field) → afterRead(col), per row.
+
+type MockCalls = ReadonlyArray<ReadonlyArray<unknown>>
+
+function unsafeCalls (pool: ReturnType<typeof makeMockPool>): MockCalls {
+  return (pool.sql.unsafe as ReturnType<typeof vi.fn>).mock.calls
+}
+
+function setup (options: {
+  rows?: Array<Record<string, string | number | null>>
+  hooks?: CollectionHooks
+  fields?: FieldConfig[]
+  drafts?: boolean
+}) {
+  const pool = makeMockPool(options.rows ?? [{ id: 'new-1', title: 'Test', slug: 'test' }])
+  const collections = createCollectionRegistry()
+  const globals = createGlobalRegistry()
+  collections.register(collection({
+    slug: 'posts',
+    fields: options.fields ?? [
+      field.text({ name: 'title', required: true }),
+      field.slug({ name: 'slug', required: true })
+    ],
+    ...(options.drafts ? { versions: { drafts: true } } : {}),
+    ...(options.hooks ? { hooks: options.hooks } : {})
+  }))
+  const api = createLocalApi(pool, collections, globals)
+  return { pool, api }
+}
+
+describe('beforeChange (collection)', () => {
+  it('fires on create with the incoming data and collection slug', async () => {
+    const hook = vi.fn((args: HookArgs) => args.data)
+    const { api } = setup({ hooks: { beforeChange: [hook] } })
+
+    const result = await api.create({ collection: 'posts', data: { title: 'New', slug: 'new' } })
+
+    expect(result.isOk()).toBe(true)
+    expect(hook).toHaveBeenCalledTimes(1)
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ title: 'New', slug: 'new' }),
+      collection: 'posts'
+    }))
+  })
+
+  it('transforms data before the INSERT', async () => {
+    const hook: HookFunction = ({ data }) => ({ ...data, title: 'From Hook' })
+    const { api, pool } = setup({ hooks: { beforeChange: [hook] } })
+
+    const result = await api.create({ collection: 'posts', data: { title: 'Original', slug: 'orig' } })
+
+    expect(result.isOk()).toBe(true)
+    const insert = unsafeCalls(pool).find(call => String(call[0]).includes('INSERT INTO'))
+    expect(insert).toBeDefined()
+    expect(insert![1]).toContain('From Hook')
+  })
+
+  it('fires on update with the document id', async () => {
+    const hook = vi.fn((args: HookArgs) => args.data)
+    const { api } = setup({ hooks: { beforeChange: [hook] } })
+
+    const result = await api.update({ collection: 'posts', id: 'abc', data: { title: 'Updated' } })
+
+    expect(result.isOk()).toBe(true)
+    expect(hook).toHaveBeenCalledTimes(1)
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'abc',
+      collection: 'posts'
+    }))
+  })
+
+  it('aborts the create when it throws — nothing is inserted', async () => {
+    const hook: HookFunction = () => {
+      throw new Error('change blocked')
+    }
+    const { api, pool } = setup({ hooks: { beforeChange: [hook] } })
+
+    const result = await api.create({ collection: 'posts', data: { title: 'New', slug: 'new' } })
+
+    expect(result.isErr()).toBe(true)
+    expect(result.isErr() && result.error.message).toContain('change blocked')
+    const insert = unsafeCalls(pool).find(call => String(call[0]).includes('INSERT INTO'))
+    expect(insert).toBeUndefined()
+  })
+})
+
+describe('afterChange (collection)', () => {
+  it('fires after create with the written row', async () => {
+    const hook = vi.fn((args: HookArgs) => args.data)
+    const { api } = setup({ hooks: { afterChange: [hook] } })
+
+    const result = await api.create({ collection: 'posts', data: { title: 'New', slug: 'new' } })
+
+    expect(result.isOk()).toBe(true)
+    expect(hook).toHaveBeenCalledTimes(1)
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ id: 'new-1' }),
+      collection: 'posts'
+    }))
+  })
+
+  it('fires after update', async () => {
+    const hook = vi.fn((args: HookArgs) => args.data)
+    const { api } = setup({ hooks: { afterChange: [hook] } })
+
+    const result = await api.update({ collection: 'posts', id: 'abc', data: { title: 'Updated' } })
+
+    expect(result.isOk()).toBe(true)
+    expect(hook).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires on publish updates, after afterPublish', async () => {
+    const calls: string[] = []
+    const { api } = setup({
+      drafts: true,
+      hooks: {
+        beforePublish: [(args: HookArgs) => { calls.push('beforePublish'); return args.data }],
+        afterPublish: [(args: HookArgs) => { calls.push('afterPublish'); return args.data }],
+        afterChange: [(args: HookArgs) => { calls.push('afterChange'); return args.data }]
+      }
+    })
+
+    const result = await api.update({ collection: 'posts', id: 'abc', data: { title: 'Live' }, publish: true })
+
+    expect(result.isOk()).toBe(true)
+    expect(calls).toEqual(['beforePublish', 'afterPublish', 'afterChange'])
+  })
+})
+
+describe('afterRead (collection)', () => {
+  it('fires on find once per returned document', async () => {
+    const hook = vi.fn((args: HookArgs) => args.data)
+    const { api } = setup({
+      rows: [
+        { id: '1', title: 'One', slug: 'one' },
+        { id: '2', title: 'Two', slug: 'two' }
+      ],
+      hooks: { afterRead: [hook] }
+    })
+
+    const result = await api.find({ collection: 'posts' })
+
+    expect(result.isOk()).toBe(true)
+    expect(hook).toHaveBeenCalledTimes(2)
+  })
+
+  it('can transform returned documents', async () => {
+    const hook: HookFunction = ({ data }) => ({ ...data, title: 'Decorated' })
+    const { api } = setup({ rows: [{ id: '1', title: 'Plain', slug: 'p' }], hooks: { afterRead: [hook] } })
+
+    const result = await api.find({ collection: 'posts' })
+
+    expect(result.isOk()).toBe(true)
+    const docs = result.isOk() ? result.value : []
+    expect(Array.isArray(docs) && docs[0]?.title).toBe('Decorated')
+  })
+
+  it('fires on findByID with the document id', async () => {
+    const hook = vi.fn((args: HookArgs) => args.data)
+    const { api } = setup({ rows: [{ id: '1', title: 'One', slug: 'one' }], hooks: { afterRead: [hook] } })
+
+    const result = await api.findByID({ collection: 'posts', id: '1' })
+
+    expect(result.isOk()).toBe(true)
+    expect(hook).toHaveBeenCalledTimes(1)
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({
+      id: '1',
+      collection: 'posts'
+    }))
+  })
+})
+
+describe('beforeValidate (field)', () => {
+  it('fires on create and can transform the field value', async () => {
+    const { api, pool } = setup({
+      fields: [
+        field.text({
+          name: 'title',
+          required: true,
+          hooks: { beforeValidate: [({ data }: HookArgs) => ({ ...data, title: 'Normalized' })] }
+        }),
+        field.slug({ name: 'slug', required: true })
+      ]
+    })
+
+    const result = await api.create({ collection: 'posts', data: { title: 'raw input', slug: 'raw' } })
+
+    expect(result.isOk()).toBe(true)
+    const insert = unsafeCalls(pool).find(call => String(call[0]).includes('INSERT INTO'))
+    expect(insert).toBeDefined()
+    expect(insert![1]).toContain('Normalized')
+  })
+
+  it('fires on update', async () => {
+    const calls: string[] = []
+    const { api } = setup({
+      fields: [
+        field.text({
+          name: 'title',
+          required: true,
+          hooks: { beforeValidate: [({ data }: HookArgs) => { calls.push('field-beforeValidate'); return data }] }
+        }),
+        field.slug({ name: 'slug', required: true })
+      ]
+    })
+
+    const result = await api.update({ collection: 'posts', id: 'abc', data: { title: 'Updated' } })
+
+    expect(result.isOk()).toBe(true)
+    expect(calls).toEqual(['field-beforeValidate'])
+  })
+})
+
+describe('canonical firing order', () => {
+  function trackingHooks (calls: string[]): CollectionHooks {
+    const track = (name: string): HookFunction => (args) => { calls.push(name); return args.data }
+    return {
+      beforeValidate: [track('beforeValidate:col')],
+      beforeChange: [track('beforeChange:col')],
+      afterChange: [track('afterChange:col')]
+    }
+  }
+
+  function trackingFields (calls: string[]): FieldConfig[] {
+    const track = (name: string): HookFunction => (args) => { calls.push(name); return args.data }
+    return [
+      field.text({
+        name: 'title',
+        required: true,
+        hooks: {
+          beforeValidate: [track('beforeValidate:field')],
+          beforeChange: [track('beforeChange:field')],
+          afterChange: [track('afterChange:field')]
+        }
+      }),
+      field.slug({ name: 'slug', required: true })
+    ]
+  }
+
+  it('create runs beforeValidate(col→field) → beforeChange(col→field) → afterChange(field→col)', async () => {
+    const calls: string[] = []
+    const { api } = setup({ hooks: trackingHooks(calls), fields: trackingFields(calls) })
+
+    const result = await api.create({ collection: 'posts', data: { title: 'New', slug: 'new' } })
+
+    expect(result.isOk()).toBe(true)
+    expect(calls).toEqual([
+      'beforeValidate:col',
+      'beforeValidate:field',
+      'beforeChange:col',
+      'beforeChange:field',
+      'afterChange:field',
+      'afterChange:col'
+    ])
+  })
+
+  it('update runs the same canonical order', async () => {
+    const calls: string[] = []
+    const { api } = setup({ hooks: trackingHooks(calls), fields: trackingFields(calls) })
+
+    const result = await api.update({ collection: 'posts', id: 'abc', data: { title: 'Updated' } })
+
+    expect(result.isOk()).toBe(true)
+    expect(calls).toEqual([
+      'beforeValidate:col',
+      'beforeValidate:field',
+      'beforeChange:col',
+      'beforeChange:field',
+      'afterChange:field',
+      'afterChange:col'
+    ])
+  })
+
+  it('publish updates nest the publish hooks around the write', async () => {
+    const calls: string[] = []
+    const track = (name: string): HookFunction => (args) => { calls.push(name); return args.data }
+    const { api } = setup({
+      drafts: true,
+      hooks: {
+        beforeChange: [track('beforeChange:col')],
+        beforePublish: [track('beforePublish')],
+        afterPublish: [track('afterPublish')],
+        afterChange: [track('afterChange:col')]
+      },
+      fields: [
+        field.text({
+          name: 'title',
+          required: true,
+          hooks: {
+            beforeChange: [track('beforeChange:field')],
+            afterChange: [track('afterChange:field')]
+          }
+        }),
+        field.slug({ name: 'slug', required: true })
+      ]
+    })
+
+    const result = await api.update({ collection: 'posts', id: 'abc', data: { title: 'Live' }, publish: true })
+
+    expect(result.isOk()).toBe(true)
+    expect(calls).toEqual([
+      'beforeChange:col',
+      'beforeChange:field',
+      'beforePublish',
+      'afterPublish',
+      'afterChange:field',
+      'afterChange:col'
+    ])
+  })
+
+  it('find runs beforeRead(col) → afterRead(field) → afterRead(col)', async () => {
+    const calls: string[] = []
+    const track = (name: string): HookFunction => (args) => { calls.push(name); return args.data }
+    const { api } = setup({
+      rows: [{ id: '1', title: 'One', slug: 'one' }],
+      hooks: {
+        beforeRead: [track('beforeRead:col')],
+        afterRead: [track('afterRead:col')]
+      },
+      fields: [
+        field.text({
+          name: 'title',
+          required: true,
+          hooks: { afterRead: [track('afterRead:field')] }
+        }),
+        field.slug({ name: 'slug', required: true })
+      ]
+    })
+
+    const result = await api.find({ collection: 'posts' })
+
+    expect(result.isOk()).toBe(true)
+    expect(calls).toEqual(['beforeRead:col', 'afterRead:field', 'afterRead:col'])
+  })
+})

--- a/packages/cms/src/api/local-api.ts
+++ b/packages/cms/src/api/local-api.ts
@@ -99,6 +99,36 @@ function runAfterHooks (
   return okAsync(result)
 }
 
+/** Run a collection hook list as a data transform; empty lists pass data through. */
+function runCollectionHookList (
+  hooks: readonly HookFunction[] | undefined,
+  data: DocumentData,
+  id: string | undefined,
+  collectionSlug: string
+): ResultAsync<DocumentData, CmsError> {
+  if (!hooks || hooks.length === 0) return okAsync(data)
+  return runHooks(hooks, { data, id, collection: collectionSlug })
+    .map((hookData) => hookData as DocumentData)
+}
+
+/** Collection afterRead runs once per returned document and may transform it. */
+function applyCollectionAfterRead (
+  hooks: readonly HookFunction[] | undefined,
+  rows: readonly DocumentRow[],
+  collectionSlug: string
+): ResultAsync<DocumentRow[], CmsError> {
+  if (!hooks || hooks.length === 0) return okAsync([...rows])
+
+  let result = okAsync<DocumentRow[], CmsError>([])
+  for (const row of rows) {
+    result = result.andThen((acc) =>
+      runHooks(hooks, { data: row, id: row.id as string | undefined, collection: collectionSlug })
+        .map((transformed) => [...acc, transformed as DocumentRow])
+    )
+  }
+  return result
+}
+
 function executeWithHooks (
   beforeHooks: readonly HookFunction[] | undefined,
   afterHooks: readonly HookFunction[] | undefined,
@@ -305,9 +335,12 @@ export function createLocalApi (
         }
         if (args.search) builder = builder.search(args.search)
         if (args.orderBy) builder = builder.orderBy(args.orderBy.field, args.orderBy.direction)
+        // Read order (#335): afterRead(field) → afterRead(col), once per
+        // document, before field-level access filtering.
         if (args.page !== undefined && args.perPage !== undefined) {
           return builder.page(args.page, args.perPage).andThen((paginated) =>
             applyFieldAfterRead(col.value.fields, paginated.docs, args.collection)
+              .andThen((docs) => applyCollectionAfterRead(col.value.hooks?.afterRead, docs, args.collection))
               .map((docs) => ({
                 ...paginated,
                 docs: docs.map((d) => applyReadFilter(d, args.collection))
@@ -317,6 +350,7 @@ export function createLocalApi (
         if (args.limit) builder = builder.limit(args.limit)
         return builder.all().andThen((rows) =>
           applyFieldAfterRead(col.value.fields, rows, args.collection)
+            .andThen((docs) => applyCollectionAfterRead(col.value.hooks?.afterRead, docs, args.collection))
             .map((docs) => docs.map((r) => applyReadFilter(r, args.collection)))
         )
       }
@@ -342,6 +376,7 @@ export function createLocalApi (
           .andThen((row) => {
             if (row === null) return okAsync(null)
             return applyFieldAfterRead(col.value.fields, [row], args.collection)
+              .andThen((rows) => applyCollectionAfterRead(col.value.hooks?.afterRead, rows, args.collection))
               .map((rows) => {
                 const doc = rows[0] ?? null
                 return doc ? applyReadFilter(doc, args.collection) : null
@@ -371,32 +406,41 @@ export function createLocalApi (
       }
 
       const fields = col.value.fields
-      const beforeValidateHooks = col.value.hooks?.beforeValidate
+      const colHooks = col.value.hooks
 
+      // Canonical write order (#335): beforeValidate(col) → beforeValidate(field)
+      // → beforeChange(col) → beforeChange(field) → INSERT → afterChange(field)
+      // → afterChange(col). Change hooks run inside the transaction; a throwing
+      // hook rolls the write back. afterChange(col) is side-effect-only — the
+      // written row is authoritative.
       const executeCreate = (createData: DocumentData): ResultAsync<DocumentRow, CmsError> =>
         ResultAsync.fromPromise(
           pool.sql.begin(async (tx) => {
             const txPool = txAsPool(tx)
             const txQb = createQueryBuilder(txPool, collections, defaultLocale)
 
+            const colChanged = await unwrapTx(
+              runCollectionHookList(colHooks?.beforeChange, createData, undefined, args.collection)
+            )
             const fieldData = await unwrapTx(
-              runFieldHooks('beforeChange', fields, createData, undefined, args.collection)
+              runFieldHooks('beforeChange', fields, colChanged, undefined, args.collection)
             )
             const filteredData = applyWriteFilter(fieldData as DocumentData, args.collection, 'create')
             const result = await unwrapTx(txQb.query(args.collection).insert(filteredData))
             const afterResult = await unwrapTx(
               runFieldHooks('afterChange', fields, result, result.id as string | undefined, args.collection)
             )
+            await unwrapTx(
+              runCollectionHookList(colHooks?.afterChange, afterResult as DocumentData, result.id as string | undefined, args.collection)
+            )
             return applyReadFilter(afterResult as DocumentRow, args.collection)
           }),
           mapTxError
         )
 
-      if (beforeValidateHooks && beforeValidateHooks.length > 0) {
-        return runHooks(beforeValidateHooks, { data, collection: args.collection })
-          .andThen((hookData) => executeCreate(hookData as DocumentData))
-      }
-      return executeCreate(data)
+      return runCollectionHookList(colHooks?.beforeValidate, data, undefined, args.collection)
+        .andThen((hookData) => runFieldHooks('beforeValidate', fields, hookData, undefined, args.collection))
+        .andThen((hookData) => executeCreate(hookData as DocumentData))
     },
 
     update (args) {
@@ -428,48 +472,52 @@ export function createLocalApi (
       }
 
       const fields = col.value.fields
-      const beforeValidateHooks = col.value.hooks?.beforeValidate
+      const colHooks = col.value.hooks
 
+      // Same canonical order as create; publish updates nest the write in
+      // beforePublish → UPDATE → afterPublish before the afterChange hooks.
       const executeUpdate = (updateData: DocumentData): ResultAsync<DocumentRow, CmsError> =>
         ResultAsync.fromPromise(
           pool.sql.begin(async (tx) => {
             const txPool = txAsPool(tx)
             const txQb = createQueryBuilder(txPool, collections, defaultLocale)
 
+            const colChanged = await unwrapTx(
+              runCollectionHookList(colHooks?.beforeChange, updateData, args.id, args.collection)
+            )
             const fieldData = await unwrapTx(
-              runFieldHooks('beforeChange', fields, updateData, args.id, args.collection)
+              runFieldHooks('beforeChange', fields, colChanged, args.id, args.collection)
             )
 
-            if (isVersioned && args.publish && col.value.hooks) {
-              const result = await unwrapTx(
+            const written = (isVersioned && args.publish && colHooks)
+              ? await unwrapTx(
                 executeWithHooks(
-                  col.value.hooks.beforePublish,
-                  col.value.hooks.afterPublish,
+                  colHooks.beforePublish,
+                  colHooks.afterPublish,
                   fieldData as DocumentData,
                   args.id,
                   args.collection,
                   (finalData) => txQb.query(args.collection).where('id', args.id).update(finalData)
                 )
               )
-              return applyReadFilter(result, args.collection)
-            }
+              : await unwrapTx(
+                txQb.query(args.collection).where('id', args.id).update(fieldData as DocumentData)
+              )
 
-            const result = await unwrapTx(
-              txQb.query(args.collection).where('id', args.id).update(fieldData as DocumentData)
-            )
             const afterResult = await unwrapTx(
-              runFieldHooks('afterChange', fields, result, args.id, args.collection)
+              runFieldHooks('afterChange', fields, written, args.id, args.collection)
+            )
+            await unwrapTx(
+              runCollectionHookList(colHooks?.afterChange, afterResult as DocumentData, args.id, args.collection)
             )
             return applyReadFilter(afterResult as DocumentRow, args.collection)
           }),
           mapTxError
         )
 
-      if (beforeValidateHooks && beforeValidateHooks.length > 0) {
-        return runHooks(beforeValidateHooks, { data, id: args.id, collection: args.collection })
-          .andThen((hookData) => executeUpdate(hookData as DocumentData))
-      }
-      return executeUpdate(data)
+      return runCollectionHookList(colHooks?.beforeValidate, data, args.id, args.collection)
+        .andThen((hookData) => runFieldHooks('beforeValidate', fields, hookData, args.id, args.collection))
+        .andThen((hookData) => executeUpdate(hookData as DocumentData))
     },
 
     delete (args) {


### PR DESCRIPTION
Closes #335.

## What the audit found

Of the 11 advertised collection lifecycle hooks, **three never fired anywhere**: collection-level `beforeChange`, `afterChange`, and `afterRead`. Field-level `beforeValidate` never fired either. This wasn't hypothetical — **plugin-seo registers a collection `beforeChange` hook for its auto-title feature, which has been dead code in every CRUD path.**

Firing before this PR: `beforeValidate`(col), `beforeRead`, `beforeDelete`/`afterDelete`, `beforePublish`/`afterPublish`, `beforeUnpublish`/`afterUnpublish`, and field `beforeChange`/`afterChange`/`afterRead`.

## The canonical order (now enforced by tests and documented)

**Writes:** `beforeValidate(col) → beforeValidate(field) → [tx: beforeChange(col) → beforeChange(field) → [beforePublish] → write → [afterPublish] → afterChange(field) → afterChange(col)]`
**Reads:** `beforeRead(col) → query → afterRead(field) → afterRead(col)` — per document, before field-level access filtering.

Semantics: change hooks run **inside the existing write transaction** — a throwing hook rolls the write back; `afterChange(col)` is side-effect-only (returned data ignored, the written row is authoritative); `afterRead(col)` may transform each returned document. Publish updates now also run `afterChange` hooks (previously the publish path skipped even field `afterChange`).

Every entry path (REST, admin, GraphQL, bulk) delegates to the Local API, so one wiring covers the matrix.

## Changes

- `local-api.ts`: `runCollectionHookList` + `applyCollectionAfterRead` helpers; create/update/find/findByID rewired to the canonical order
- `docs/guide.md`: definitive firing-order section with the transaction boundary drawn
- 16-test matrix in `lifecycle-hooks-matrix.test.ts`: firing, payload shape (`data`/`id`/`collection`), transform-reaches-INSERT assertions, abort-rolls-back, and full order assertions for create/update/publish/find

## Known limitation (documented, deliberate)

Localized-merge updates (`update` with `locale` on localized fields) still bypass change hooks — the jsonb merge semantics predate hook wiring. Flagged in the guide and tracked with #334 (transactional integrity), which also owns the after*-hooks-post-commit decision and revision atomicity.

## Validation

- TDD: RED (16 failing) → GREEN → REFACTOR; sequence check passes
- Full `@valencets/cms` suite: **1443/1443** (zero regressions across 121 files)
- plugin-seo, plugin-nested-docs, graphql suites green — the SEO auto-title hook now actually runs
- tsc, eslint, banned-patterns green; `cms.api.md` unchanged