### PR TITLE
fix(valence): migration column-naming validation queries a closed pool (#351)

### DIFF
--- a/packages/valence/src/__tests__/migration-checks.test.ts
+++ b/packages/valence/src/__tests__/migration-checks.test.ts
@@ -70,10 +70,12 @@ describe('cli wiring', () => {
     const fnStart = source.indexOf('async function runMigrationsForProject')
     const fnBody = source.slice(fnStart, source.indexOf('export async function seedDatabase'))
     const validateAt = fnBody.indexOf('validateColumnNaming(')
-    const closeAt = fnBody.indexOf('closePool(pool)')
+    // The error branch closes the pool early and legitimately skips the
+    // lint; the success path's close is the LAST one in the function.
+    const successCloseAt = fnBody.lastIndexOf('closePool(pool)')
 
     expect(validateAt).toBeGreaterThan(-1)
-    expect(closeAt).toBeGreaterThan(-1)
-    expect(validateAt).toBeLessThan(closeAt)
+    expect(successCloseAt).toBeGreaterThan(-1)
+    expect(validateAt).toBeLessThan(successCloseAt)
   })
 })

--- a/packages/valence/src/__tests__/migration-checks.test.ts
+++ b/packages/valence/src/__tests__/migration-checks.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+import { validateColumnNaming } from '../migration-checks.js'
+import type { DbPool } from '@valencets/db'
+
+// #351 — the column-naming validation used to run AFTER closePool, so every
+// query rejected against the closed pool and the warnings were dead code.
+// Extracted here so it runs on a live pool and stays testable.
+
+function schemaPool (tables: Record<string, string[]>): DbPool {
+  const unsafe = vi.fn(async (text: string, params?: readonly string[]) => {
+    if (text.includes('information_schema.tables')) {
+      return Object.keys(tables).map(name => ({ table_name: name }))
+    }
+    if (text.includes('information_schema.columns')) {
+      const cols = tables[String(params?.[0])] ?? []
+      return cols.map(name => ({ column_name: name }))
+    }
+    return []
+  })
+  return { sql: Object.assign(vi.fn(), { unsafe }) } as unknown as DbPool
+}
+
+describe('validateColumnNaming', () => {
+  it('warns about camelCase system columns with a rename hint', async () => {
+    const warnings: string[] = []
+    const pool = schemaPool({ posts: ['id', 'createdAt', 'updated_at', 'deleted_at', 'created_at'] })
+
+    await validateColumnNaming(pool, (msg) => { warnings.push(msg) })
+
+    expect(warnings.some(w => w.includes('createdAt') && w.includes('created_at') && w.includes('posts'))).toBe(true)
+    expect(warnings.some(w => w.includes('RENAME COLUMN'))).toBe(true)
+  })
+
+  it('warns when a CMS-shaped table is missing deleted_at', async () => {
+    const warnings: string[] = []
+    const pool = schemaPool({ posts: ['id', 'created_at', 'updated_at'] })
+
+    await validateColumnNaming(pool, (msg) => { warnings.push(msg) })
+
+    expect(warnings.some(w => w.includes('deleted_at') && w.includes('posts'))).toBe(true)
+  })
+
+  it('stays silent for conforming tables', async () => {
+    const warnings: string[] = []
+    const pool = schemaPool({ posts: ['id', 'title', 'created_at', 'updated_at', 'deleted_at'] })
+
+    await validateColumnNaming(pool, (msg) => { warnings.push(msg) })
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('never throws — query failures resolve silently (best-effort check)', async () => {
+    const unsafe = vi.fn(async () => Promise.reject(new Error('connection closed')))
+    const pool = { sql: Object.assign(vi.fn(), { unsafe }) } as unknown as DbPool
+
+    await expect(validateColumnNaming(pool, () => {})).resolves.toBeUndefined()
+  })
+})
+
+describe('cli wiring', () => {
+  it('runs the validation before the pool closes', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { join, dirname } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const source = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', 'cli.ts'),
+      'utf-8'
+    ).replace(/\r\n/g, '\n')
+
+    const fnStart = source.indexOf('async function runMigrationsForProject')
+    const fnBody = source.slice(fnStart, source.indexOf('export async function seedDatabase'))
+    const validateAt = fnBody.indexOf('validateColumnNaming(')
+    const closeAt = fnBody.indexOf('closePool(pool)')
+
+    expect(validateAt).toBeGreaterThan(-1)
+    expect(closeAt).toBeGreaterThan(-1)
+    expect(validateAt).toBeLessThan(closeAt)
+  })
+})

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -15,6 +15,7 @@ import { readLearnProgress, writeLearnProgress, createInitialProgress } from './
 import { log } from './cli-utils.js'
 import { generateConfigTemplate, generateSecret } from './config-template.js'
 import { validateProductionSecret } from './secret-guard.js'
+import { validateColumnNaming } from './migration-checks.js'
 import { parseInitFlags, askWithDefault, confirmWithDefault, createDbInvocations, migrationTargets, initSummary, createPromptQueue, scaffoldDependencies } from './init-steps.js'
 import { landingPage } from './landing-page.js'
 import { loadEnvConfig, loadUserConfig, registerTsxLoader } from './config-loader.js'
@@ -1326,42 +1327,17 @@ async function runMigrationsForProject (projectDir: string, config: DbConfig): P
   }
 
   const result = await runMigrations(pool, migrations)
-  await closePool(pool)
 
   if (result.isErr()) {
+    await closePool(pool)
     log(`Migration error: ${result.error.message}`)
     return false
   }
 
-  // Validate column naming conventions on all tables (best-effort, non-fatal)
-  await ResultAsync.fromPromise(
-    (async () => {
-      const tables = await pool.sql.unsafe(
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'"
-      )
-      for (const t of tables) {
-        const tableName = String(Reflect.get(t, 'table_name') ?? '')
-        const cols = await pool.sql.unsafe(
-          "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1",
-          [tableName]
-        )
-        const colNames = Array.from(cols).map(c => String(Reflect.get(c, 'column_name') ?? ''))
-        // Check for camelCase system columns (common mistake)
-        const camelCaseSystemCols = ['createdAt', 'updatedAt', 'deletedAt']
-        for (const bad of camelCaseSystemCols) {
-          if (colNames.includes(bad)) {
-            const snakeVersion = bad.replace(/([A-Z])/g, '_$1').toLowerCase()
-            log(`  ⚠ Table "${tableName}" has "${bad}" — CMS expects "${snakeVersion}". Run: ALTER TABLE "${tableName}" RENAME COLUMN "${bad}" TO ${snakeVersion};`)
-          }
-        }
-        // Check if CMS system columns are missing
-        if (!colNames.includes('deleted_at') && colNames.includes('created_at')) {
-          log(`  ⚠ Table "${tableName}" is missing "deleted_at" column — CMS soft-delete will not work.`)
-        }
-      }
-    })(),
-    () => null
-  )
+  // #351 — the naming lint must see a LIVE pool; it used to run after
+  // closePool, where every query rejected and the warnings never fired.
+  await validateColumnNaming(pool, log)
+  await closePool(pool)
 
   log(`Applied ${result.value} migration(s).`)
   return true

--- a/packages/valence/src/migration-checks.ts
+++ b/packages/valence/src/migration-checks.ts
@@ -1,0 +1,42 @@
+import { ResultAsync } from '@valencets/resultkit'
+import type { DbPool } from '@valencets/db'
+
+const CAMEL_CASE_SYSTEM_COLS = ['createdAt', 'updatedAt', 'deletedAt'] as const
+
+/**
+ * Best-effort post-migration lint (#351): warn about the schema mistakes
+ * the CMS trips over most — camelCase system columns and missing
+ * `deleted_at` (soft delete). Must run on a LIVE pool, before closePool;
+ * failures resolve silently because a broken information_schema query must
+ * never fail a successful migration run.
+ */
+export function validateColumnNaming (pool: DbPool, log: (msg: string) => void): Promise<void> {
+  return ResultAsync.fromPromise(
+    (async () => {
+      const tables = await pool.sql.unsafe(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'"
+      )
+      for (const t of tables) {
+        const tableName = String(Reflect.get(t, 'table_name') ?? '')
+        const cols = await pool.sql.unsafe(
+          "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1",
+          [tableName]
+        )
+        const colNames = Array.from(cols).map(c => String(Reflect.get(c, 'column_name') ?? ''))
+        for (const bad of CAMEL_CASE_SYSTEM_COLS) {
+          if (colNames.includes(bad)) {
+            const snakeVersion = bad.replace(/([A-Z])/g, '_$1').toLowerCase()
+            log(`  ⚠ Table "${tableName}" has "${bad}" — CMS expects "${snakeVersion}". Run: ALTER TABLE "${tableName}" RENAME COLUMN "${bad}" TO ${snakeVersion};`)
+          }
+        }
+        if (!colNames.includes('deleted_at') && colNames.includes('created_at')) {
+          log(`  ⚠ Table "${tableName}" is missing "deleted_at" column — CMS soft-delete will not work.`)
+        }
+      }
+    })(),
+    () => null
+  ).match(
+    () => undefined,
+    () => undefined
+  )
+}


### PR DESCRIPTION
Closes #351.

## What

`runMigrationsForProject` ran its best-effort column-naming lint (camelCase system columns, missing `deleted_at`) **after** `await closePool(pool)` — every query rejected against the closed pool, the `fromPromise(…, () => null)` wrapper swallowed it, and the warnings were dead code. These warnings exist precisely to catch the most common dogfood-reported schema mistake (#325 context).

## Changes

- Extracted the lint into `migration-checks.ts` (`validateColumnNaming(pool, log)`) — testable against a mock pool, still best-effort (query failures resolve silently, never fail a successful migration run)
- `cli.ts`: success path now runs `validateColumnNaming` **before** `closePool`; the error branch still closes early and skips the lint
- Source-order guard test pins validate-before-close on the success path

## Validation

- TDD: RED (module missing) → GREEN; sequence check passes
- 5 new tests: camelCase warning + RENAME hint, missing `deleted_at` warning, silence for conforming tables, no-throw on query failure, cli ordering guard
- tsc, eslint, banned-patterns green