### PR TITLE
docs(cms): document the REST query filtering surface + reflect it in OpenAPI (#344)

### DIFF
--- a/packages/cms/docs/guide.md
+++ b/packages/cms/docs/guide.md
@@ -298,6 +298,44 @@ const server = createServer(async (req, res) => {
 server.listen(3000)
 ```
 
+### REST query surface
+
+Every collection's list endpoint (`GET /api/:slug`) accepts the same query
+parameters — discovered by the dogfood build, documented here, and mirrored
+by the OpenAPI spec at `GET /api/docs` (#344):
+
+| Parameter | Meaning | Constraints |
+|---|---|---|
+| `page` | Page number | integer, min 1, default 1 |
+| `limit` | Items per page | integer, 1–100, default 25 |
+| `search` | Full-text search across the collection | tsvector-backed |
+| `sort` | Field to sort by | **allow-listed**: schema fields + `id`/`created_at`/`updated_at`/`deleted_at`; anything else is 400 |
+| `dir` | Sort direction | `asc` (default) or `desc` |
+| `draft` | Include drafts | `true` on versioned collections |
+| `locale` | Locale for localized fields | must exist in the localization config, else 400 |
+| `<field>` | Equality filter, one per schema field | allow-listed; unknown fields are 400; `'true'`/`'false'` coerce to booleans |
+
+Examples:
+
+```
+GET /api/posts?published=true&sort=created_at&dir=desc&page=2&limit=10
+GET /api/posts?slug=hello-world
+GET /api/posts?search=valence&draft=true
+```
+
+Responses are paginated: `{ docs, totalDocs, page, totalPages, limit, hasNextPage, hasPrevPage }`.
+
+Richer operators (`not_equals`, `greater_than`, `less_than`, `like`, `in`,
+`exists`, and/or clauses) are available server-side through the Local API's
+`whereClause` — the HTTP surface deliberately stays equality-only.
+
+Related endpoints: `POST /api/:slug?draft=true` (create as draft),
+`PATCH /api/:slug/:id?publish=true` (publish on update),
+`POST /api/:slug/:id/unpublish`, and `POST /api/:slug/bulk` with
+`{ action: 'delete' | 'publish' | 'unpublish', ids: […] }` (max 100 ids).
+All endpoints require a `cms_session` cookie unless the collection defines
+its own `access` rules.
+
 ## 4. Using the Local API
 
 The local API is for server-side code that needs direct database access without going through HTTP:

--- a/packages/cms/src/__tests__/openapi.test.ts
+++ b/packages/cms/src/__tests__/openapi.test.ts
@@ -107,7 +107,8 @@ describe('generateOpenApiSpec()', () => {
     const params = listOp?.parameters
 
     expect(params).toBeDefined()
-    expect(params).toHaveLength(2)
+    // page + limit + search + sort + dir + locale + one filter per field (#344)
+    expect(params!.length).toBeGreaterThanOrEqual(2)
 
     const pageParam = params?.find(p => p.name === 'page')
     expect(pageParam?.in).toBe('query')

--- a/packages/cms/src/__tests__/openapi.test.ts
+++ b/packages/cms/src/__tests__/openapi.test.ts
@@ -121,6 +121,53 @@ describe('generateOpenApiSpec()', () => {
     expect(limitParam?.schema.maximum).toBe(100)
   })
 
+  // #344 — the REST list endpoint accepts search/sort/dir/draft/locale and
+  // per-field equality filters; /api/docs must reflect the same surface.
+  describe('query surface parameters (#344)', () => {
+    function listParams (versioned = false) {
+      const registry = makeRegistry(
+        collection({
+          slug: 'posts',
+          fields: [
+            field.text({ name: 'title', required: true }),
+            field.boolean({ name: 'published' })
+          ],
+          ...(versioned ? { versions: { drafts: true } } : {})
+        })
+      )
+      const spec = generateOpenApiSpec(registry)
+      return spec.paths['/api/posts']!.get!.parameters ?? []
+    }
+
+    it('documents search, sort, dir, and locale on the list endpoint', () => {
+      const names = listParams().map(p => p.name)
+      expect(names).toContain('search')
+      expect(names).toContain('sort')
+      expect(names).toContain('dir')
+      expect(names).toContain('locale')
+    })
+
+    it('documents dir as an asc/desc enum', () => {
+      const dir = listParams().find(p => p.name === 'dir')
+      expect(dir).toBeDefined()
+      expect(dir!.schema.enum).toEqual(['asc', 'desc'])
+    })
+
+    it('documents one equality filter parameter per schema field', () => {
+      const params = listParams()
+      const title = params.find(p => p.name === 'title')
+      const published = params.find(p => p.name === 'published')
+      expect(title).toBeDefined()
+      expect(title!.in).toBe('query')
+      expect(published).toBeDefined()
+    })
+
+    it('documents draft only for versioned collections', () => {
+      expect(listParams(false).map(p => p.name)).not.toContain('draft')
+      expect(listParams(true).map(p => p.name)).toContain('draft')
+    })
+  })
+
   it('generates paginated response schema', () => {
     const registry = makeRegistry(
       collection({ slug: 'posts', fields: [field.text({ name: 'title' })] })

--- a/packages/cms/src/api/openapi.ts
+++ b/packages/cms/src/api/openapi.ts
@@ -49,7 +49,7 @@ interface OpenApiParameter {
   readonly in: string
   readonly required?: boolean
   readonly description?: string
-  readonly schema: { readonly type: string; readonly format?: string; readonly default?: number; readonly minimum?: number; readonly maximum?: number }
+  readonly schema: { readonly type: string; readonly format?: string; readonly default?: number | string; readonly minimum?: number; readonly maximum?: number; readonly enum?: readonly string[] }
 }
 
 interface OpenApiOperation {
@@ -245,13 +245,33 @@ function buildCollectionPaths (config: CollectionConfig): Record<string, OpenApi
   const listPath = `/api/${config.slug}`
   const itemPath = `/api/${config.slug}/{id}`
 
+  // #344 — /api/docs must reflect the full query surface the REST layer
+  // accepts: pagination, search, allow-listed sort, drafts, locale, and one
+  // equality filter per schema field (values coerce: 'true'/'false' → bool).
+  const filterParams: OpenApiParameter[] = flattenFields(config.fields).map((f) => ({
+    name: f.name,
+    in: 'query',
+    description: `Filter by ${f.name} (equality; 'true'/'false' coerce to booleans)`,
+    schema: { type: 'string' }
+  }))
+
+  const draftParam: OpenApiParameter[] = config.versions?.drafts === true
+    ? [{ name: 'draft', in: 'query', description: 'Include draft documents', schema: { type: 'string', enum: ['true', 'false'] } }]
+    : []
+
   const listOp: OpenApiOperation = {
     summary: `List ${label}`,
     tags: [tag],
     security,
     parameters: [
       { name: 'page', in: 'query', description: 'Page number', schema: { type: 'integer', default: 1, minimum: 1 } },
-      { name: 'limit', in: 'query', description: 'Items per page', schema: { type: 'integer', default: 25, minimum: 1, maximum: 100 } }
+      { name: 'limit', in: 'query', description: 'Items per page', schema: { type: 'integer', default: 25, minimum: 1, maximum: 100 } },
+      { name: 'search', in: 'query', description: 'Full-text search across the collection', schema: { type: 'string' } },
+      { name: 'sort', in: 'query', description: 'Field to sort by (schema fields and system columns only)', schema: { type: 'string' } },
+      { name: 'dir', in: 'query', description: 'Sort direction', schema: { type: 'string', enum: ['asc', 'desc'], default: 'asc' } },
+      { name: 'locale', in: 'query', description: 'Locale for localized fields (requires localization config)', schema: { type: 'string' } },
+      ...draftParam,
+      ...filterParams
     ],
     responses: {
       200: {


### PR DESCRIPTION
Closes #344.

## What

The REST list query surface (filters, search, sort, pagination, drafts, locale) worked but was undocumented — the dogfood author discovered it by reading framework source. Two deliverables:

1. **`packages/cms/docs/guide.md`** — full parameter table with constraints (allow-listing behavior, 400 semantics, limit cap 100, boolean coercion), examples, the pagination envelope, the Local-API-only `whereClause` operators note, and the related draft/publish/bulk endpoints.
2. **OpenAPI generator** — `GET /api/docs` list operations now document `search`, `sort`, `dir` (asc/desc enum), `locale`, `draft` (versioned collections only), and one equality-filter parameter per schema field, matching what `rest-api.ts` actually accepts.

## Validation

- TDD: RED (4 failing spec tests) → GREEN → REFACTOR; sequence check passes
- One stale exclusivity assertion updated (`parameters` was pinned to exactly `[page, limit]`)
- `@valencets/cms` 1447/1447; tsc, eslint green; `cms.api.md` unchanged