### PR TITLE
integrity(valence): mount telemetry ingestion — and fix the DOM-crash chain that blocked it (#349)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,10 @@
       "types": "./dist/client/index.d.ts",
       "default": "./dist/client/index.js"
     },
+    "./telemetry": {
+      "types": "./dist/telemetry/index.d.ts",
+      "default": "./dist/telemetry/index.js"
+    },
     "./server": {
       "types": "./dist/server/index.d.ts",
       "default": "./dist/server/index.js"

--- a/packages/core/src/client/__tests__/node-import.test.ts
+++ b/packages/core/src/client/__tests__/node-import.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+
+// #349 audit — fragment-swap executed `new DOMParser()` at module scope,
+// so any transitive import in a DOM-less runtime crashed with
+// "DOMParser is not defined" (e.g. `valence telemetry:aggregate` importing
+// @valencets/telemetry → init.ts → core client modules). DOM construction
+// must be lazy: importable everywhere, DOM required only at call time.
+
+describe('DOM-less runtime imports', () => {
+  it('fragment-swap imports without a DOM', async () => {
+    const mod = await import('../../router/fragment-swap.js')
+    expect(typeof mod.parseHtml).toBe('function')
+  })
+
+  it('the telemetry engine imports without a DOM', async () => {
+    const mod = await import('../../telemetry/index.js')
+    expect(mod).toBeDefined()
+  })
+
+  it('parseHtml still works when a DOM exists at call time', async () => {
+    const { Window } = await import('happy-dom')
+    const window = new Window()
+    const globalWithDom = globalThis as { DOMParser?: unknown }
+    const previous = globalWithDom.DOMParser
+    globalWithDom.DOMParser = window.DOMParser
+
+    const { parseHtml } = await import('../../router/fragment-swap.js')
+    const result = parseHtml('<html><body><p>hi</p></body></html>')
+
+    expect(result.isOk()).toBe(true)
+
+    if (previous === undefined) {
+      delete globalWithDom.DOMParser
+    } else {
+      globalWithDom.DOMParser = previous
+    }
+  })
+})

--- a/packages/core/src/router/fragment-swap.ts
+++ b/packages/core/src/router/fragment-swap.ts
@@ -11,7 +11,16 @@ export const supportsMoveBefore: boolean =
   typeof Element !== 'undefined' &&
   hasMoveBefore(Element.prototype)
 
-const parser = new DOMParser()
+// Lazy — constructing at module scope crashed every transitive import in
+// DOM-less runtimes (node CLIs importing @valencets/telemetry → core/client).
+let parser: DOMParser | null = null
+
+function getParser (): DOMParser {
+  if (parser === null) {
+    parser = new DOMParser()
+  }
+  return parser
+}
 
 export function parseHtml (html: string): Result<Document, RouterError> {
   if (html === '') {
@@ -21,7 +30,7 @@ export function parseHtml (html: string): Result<Document, RouterError> {
     })
   }
 
-  const doc = parser.parseFromString(html, 'text/html')
+  const doc = getParser().parseFromString(html, 'text/html')
   return ok(doc)
 }
 

--- a/packages/telemetry/src/__tests__/handler.test.ts
+++ b/packages/telemetry/src/__tests__/handler.test.ts
@@ -1,7 +1,26 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createIngestionHandler } from '../handler.js'
+import type { DbPool } from '@valencets/db'
 
 import { makeMockPool } from '@valencets/db/test'
+
+// A pool whose every entry point counts invocations — lets tests assert
+// the database was never touched.
+function countingPool (): { pool: DbPool; touched: () => number } {
+  const tagged = vi.fn(async () => Object.assign([{ session_id: 's1' }], { count: 1 }))
+  const sql = Object.assign(
+    tagged,
+    {
+      unsafe: vi.fn(async () => []),
+      json: (v: unknown) => v,
+      begin: vi.fn(async () => undefined)
+    }
+  )
+  return {
+    pool: { sql } as unknown as DbPool,
+    touched: () => tagged.mock.calls.length + sql.unsafe.mock.calls.length
+  }
+}
 
 function mockReq (body: string, method = 'POST', headers?: Record<string, string>): import('node:http').IncomingMessage {
   const req = {
@@ -66,6 +85,39 @@ describe('createIngestionHandler', () => {
     await handler(mockReq(payload), res as never)
     expect(res._status).toBe(200)
   })
+
+  // #349 audit — the beacon endpoint buffered request bodies without any
+  // size cap and waited for 'end' forever. Once the cap is exceeded the
+  // handler must answer immediately (silent-accept 200, nothing stored)
+  // instead of buffering an attacker's unbounded stream.
+  it('answers oversized bodies at the cap without waiting for the stream to end', async () => {
+    const { pool, touched } = countingPool()
+    const handler = createIngestionHandler({ pool })
+
+    // A stream that pushes 300 KB and never emits 'end'
+    const { EventEmitter } = await import('node:events')
+    const emitter = new EventEmitter()
+    const req = Object.assign(emitter, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      url: '/api/telemetry'
+    })
+    setTimeout(() => {
+      for (let i = 0; i < 30; i++) {
+        emitter.emit('data', Buffer.alloc(10_000, 120))
+      }
+      // no 'end' — the handler must have already answered
+    }, 0)
+
+    const res = mockRes()
+    await handler(req as never, res as never)
+
+    expect(res._status).toBe(200)
+    const body = JSON.parse(res._body) as { ok: boolean; ingested: number }
+    expect(body.ok).toBe(true)
+    expect(body.ingested).toBe(0)
+    expect(touched()).toBe(0)
+  }, 4000)
 
   it('returns 200 on invalid payload (silent accept)', async () => {
     const pool = makeMockPool([])

--- a/packages/telemetry/src/__tests__/node-barrel.test.ts
+++ b/packages/telemetry/src/__tests__/node-barrel.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+
+// #349 audit — the barrel pulled @valencets/core/client (router included),
+// whose Web Component classes evaluate DOM globals at import time. Any
+// plain-node consumer crashed: `valence telemetry:aggregate` dynamic-imports
+// this barrel and has been broken since init.ts landed. The barrel must
+// import cleanly in a DOM-less runtime; DOM is a call-time concern of
+// initTelemetry only.
+
+describe('@valencets/telemetry barrel in a DOM-less runtime', () => {
+  it('imports without a DOM', async () => {
+    const mod = await import('../index.js')
+    expect(typeof mod.createIngestionHandler).toBe('function')
+    expect(typeof mod.initTelemetry).toBe('function')
+    expect(typeof mod.aggregateSessionSummary).toBe('function')
+  })
+})

--- a/packages/telemetry/src/handler.ts
+++ b/packages/telemetry/src/handler.ts
@@ -53,10 +53,32 @@ export function createIngestionHandler (
   }
 }
 
+// #349 audit — sendBeacon payloads are tiny (browsers cap around 64 KB);
+// anything past this is hostile. At the cap the promise settles
+// immediately with an empty body — downstream validation fails it into the
+// silent-accept 200 path and nothing buffers past the limit.
+const MAX_BEACON_BYTES = 256 * 1024
+
 function readRequestBody (req: IncomingMessage): Promise<string> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => { chunks.push(chunk) })
-    req.on('end', () => { resolve(Buffer.concat(chunks).toString()) })
+    let total = 0
+    let settled = false
+    const settle = (body: string): void => {
+      if (settled) return
+      settled = true
+      resolve(body)
+    }
+    req.on('data', (chunk: Buffer) => {
+      if (settled) return
+      total += chunk.length
+      if (total > MAX_BEACON_BYTES) {
+        chunks.length = 0
+        settle('')
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => { settle(Buffer.concat(chunks).toString()) })
   })
 }

--- a/packages/telemetry/src/init.ts
+++ b/packages/telemetry/src/init.ts
@@ -1,13 +1,16 @@
 import { ok, err } from '@valencets/resultkit'
 import type { Result } from '@valencets/resultkit'
+// The engine subpath is import-safe in DOM-less runtimes — the full
+// /client barrel evaluates Web Component classes at import time and
+// crashes plain node (which imports this barrel via the CLI aggregator).
 import {
   TelemetryRingBuffer,
   initEventDelegation,
   scheduleAutoFlush,
   IntentType,
   shouldTrack
-} from '@valencets/core/client'
-import type { TelemetryError } from '@valencets/core/client'
+} from '@valencets/core/telemetry'
+import type { TelemetryError } from '@valencets/core/telemetry'
 
 export interface TelemetryConfig {
   readonly endpoint: string

--- a/packages/telemetry/telemetry.api.md
+++ b/packages/telemetry/telemetry.api.md
@@ -10,7 +10,7 @@ import type { IncomingMessage } from 'node:http';
 import type { Result } from '@valencets/resultkit';
 import { ResultAsync } from '@valencets/resultkit';
 import type { ServerResponse } from 'node:http';
-import type { TelemetryError } from '@valencets/core/client';
+import type { TelemetryError } from '@valencets/core/telemetry';
 
 // @public (undocumented)
 export function aggregateConversionSummary(pool: DbPool, period: SummaryPeriod): ResultAsync<ReadonlyArray<ConversionSummaryRow>, DbError>;

--- a/packages/valence/src/__tests__/telemetry-wiring.test.ts
+++ b/packages/valence/src/__tests__/telemetry-wiring.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { DbPool } from '@valencets/db'
+import { maybeRegisterTelemetry } from '../telemetry-wiring.js'
+import type { RouteHandler } from '../define-config.js'
+
+// #349 — the config promises `telemetry.endpoint` and the client beacons
+// to it, but nothing mounted the ingestion handler: beacons 404'd. The
+// wiring registers the silent-accept handler at the configured endpoint.
+
+function collectRoutes (): { registerRoute: (method: string, path: string, handler: RouteHandler) => void; routes: Map<string, RouteHandler> } {
+  const routes = new Map<string, RouteHandler>()
+  return {
+    registerRoute: (method, path, handler) => { routes.set(`${method} ${path}`, handler) },
+    routes
+  }
+}
+
+function beaconPool (): DbPool {
+  const tagged = vi.fn(async () => Object.assign([{ session_id: 's1' }], { count: 1 }))
+  const sql = Object.assign(tagged, {
+    unsafe: vi.fn(async () => []),
+    json: (v: unknown) => v,
+    begin: vi.fn(async () => undefined)
+  })
+  return { sql } as unknown as DbPool
+}
+
+function postReq (body: string, headers?: { [key: string]: string }): IncomingMessage {
+  const emitter = new EventEmitter()
+  const req = Object.assign(emitter, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...(headers ?? {}) },
+    url: '/api/telemetry'
+  })
+  setTimeout(() => {
+    emitter.emit('data', Buffer.from(body))
+    emitter.emit('end')
+  }, 0)
+  return req as unknown as IncomingMessage
+}
+
+function mockRes (): ServerResponse & { _status: number; _body: string } {
+  const res = {
+    _status: 0,
+    _body: '',
+    headersSent: false,
+    writeHead (status: number) { res._status = status; return res },
+    setHeader () { return res },
+    end (body?: string) { res._body = body ?? ''; res.headersSent = true }
+  }
+  return res as unknown as ServerResponse & { _status: number; _body: string }
+}
+
+describe('maybeRegisterTelemetry', () => {
+  it('mounts POST at the configured endpoint when telemetry is enabled', () => {
+    const { registerRoute, routes } = collectRoutes()
+
+    const mounted = maybeRegisterTelemetry(
+      { enabled: true, endpoint: '/api/telemetry', siteId: 'test' },
+      registerRoute,
+      beaconPool()
+    )
+
+    expect(mounted).toBe(true)
+    expect(routes.has('POST /api/telemetry')).toBe(true)
+  })
+
+  it('mounts nothing when telemetry is disabled or unconfigured', () => {
+    const { registerRoute, routes } = collectRoutes()
+
+    expect(maybeRegisterTelemetry(undefined, registerRoute, beaconPool())).toBe(false)
+    expect(maybeRegisterTelemetry({ enabled: false, endpoint: '/api/telemetry', siteId: 'test' }, registerRoute, beaconPool())).toBe(false)
+    expect(routes.size).toBe(0)
+  })
+
+  it('the mounted handler answers a valid beacon with the silent-accept envelope', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    maybeRegisterTelemetry({ enabled: true, endpoint: '/api/telemetry', siteId: 'test' }, registerRoute, beaconPool())
+
+    const payload = JSON.stringify([{
+      id: 'evt-1',
+      timestamp: Date.now(),
+      type: 'CLICK',
+      targetDOMNode: 'button.cta',
+      x_coord: 1,
+      y_coord: 2,
+      isDirty: false,
+      schema_version: 1,
+      site_id: 'test-site',
+      path: '/',
+      referrer: ''
+    }])
+    const res = mockRes()
+    await routes.get('POST /api/telemetry')!(postReq(payload), res, {})
+
+    expect(res._status).toBe(200)
+    expect(JSON.parse(res._body).ok).toBe(true)
+  })
+
+  it('respects DNT on the mounted endpoint', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    const pool = beaconPool()
+    maybeRegisterTelemetry({ enabled: true, endpoint: '/api/telemetry', siteId: 'test' }, registerRoute, pool)
+
+    const res = mockRes()
+    await routes.get('POST /api/telemetry')!(postReq('[]', { dnt: '1' }), res, {})
+
+    expect(res._status).toBe(200)
+    expect(JSON.parse(res._body).ingested).toBe(0)
+    expect((pool.sql as unknown as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0)
+  })
+})
+
+describe('cli wiring', () => {
+  it('both runDev and runStart mount the ingestion endpoint', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { join, dirname } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const source = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', 'cli.ts'),
+      'utf-8'
+    ).replace(/\r\n/g, '\n')
+
+    const mounts = source.match(/maybeRegisterTelemetry\(/g) ?? []
+    // one import + one call in runDev + one call in runStart
+    expect(mounts.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -16,6 +16,7 @@ import { log } from './cli-utils.js'
 import { generateConfigTemplate, generateSecret } from './config-template.js'
 import { validateProductionSecret } from './secret-guard.js'
 import { validateColumnNaming } from './migration-checks.js'
+import { maybeRegisterTelemetry } from './telemetry-wiring.js'
 import { parseInitFlags, askWithDefault, confirmWithDefault, createDbInvocations, migrationTargets, initSummary, createPromptQueue, scaffoldDependencies } from './init-steps.js'
 import { landingPage } from './landing-page.js'
 import { loadEnvConfig, loadUserConfig, registerTsxLoader } from './config-loader.js'
@@ -815,6 +816,9 @@ async function runDev (): Promise<void> {
   const { maybeRegisterStores } = await import('./store-wiring.js')
   const storeHydrator = maybeRegisterStores(loadedConfig.stores, registerRoute, log, pool, devCmsSecret, clientBundleUrl)
 
+  // Mount beacon ingestion at the configured endpoint (#349)
+  maybeRegisterTelemetry(loadedConfig.telemetry, registerRoute, pool, log)
+
   // Schema-driven generated route map (custom routes take priority)
   const generatedRoutes = generateCollectionRoutes(userConfig, loadedConfig.routes)
   const generatedRouteMap = buildGeneratedRouteMap(generatedRoutes, projectDir, storeHydrator)
@@ -1073,6 +1077,9 @@ export async function runStart (): Promise<void> {
   // Register store routes (no-op if no stores defined)
   const { maybeRegisterStores: maybeRegisterStoresProd } = await import('./store-wiring.js')
   const storeHydrator = maybeRegisterStoresProd(loadedConfig.stores, registerRoute, undefined, pool, cmsSecret, clientBundleUrl)
+
+  // Mount beacon ingestion at the configured endpoint (#349)
+  maybeRegisterTelemetry(loadedConfig.telemetry, registerRoute, pool, log)
 
   // Schema-driven generated route map (custom routes take priority)
   const generatedRoutes = generateCollectionRoutes(userConfig, loadedConfig.routes)

--- a/packages/valence/src/telemetry-wiring.ts
+++ b/packages/valence/src/telemetry-wiring.ts
@@ -1,0 +1,33 @@
+import type { DbPool } from '@valencets/db'
+import { createIngestionHandler } from '@valencets/telemetry'
+import type { RouteHandler } from './define-config.js'
+
+export interface TelemetryWiringConfig {
+  readonly enabled: boolean
+  readonly endpoint: string
+  readonly siteId: string
+}
+
+/**
+ * #349 — mount the beacon ingestion endpoint the config promises. The
+ * client telemetry engine beacons to `telemetry.endpoint`; without this
+ * mount every beacon fell through to the 404 handler and the analytics
+ * tables never filled. Registered as a custom route so it wins over the
+ * REST `/api/:slug` pattern.
+ */
+export function maybeRegisterTelemetry (
+  telemetry: TelemetryWiringConfig | undefined,
+  registerRoute: (method: string, path: string, handler: RouteHandler) => void,
+  pool: DbPool,
+  logFn?: (msg: string) => void
+): boolean {
+  if (telemetry === undefined || !telemetry.enabled) return false
+
+  const handler = createIngestionHandler({ pool })
+  registerRoute('POST', telemetry.endpoint, async (req, res) => {
+    await handler(req, res)
+  })
+
+  if (logFn) logFn(`Telemetry ingestion mounted at ${telemetry.endpoint}`)
+  return true
+}


### PR DESCRIPTION
Closes #349.

## What

The scaffolded config promises `telemetry: { endpoint: '/api/telemetry', … }` and the client engine beacons there — but nothing mounted the ingestion handler, so every beacon 404'd and the analytics tables never filled. Mounting it exposed **two deeper bugs**, both fixed here with their own TDD pairs:

### 1. `@valencets/telemetry` crashed plain node at import (pre-existing, live)

`init.ts` imported `@valencets/core/client`, whose barrel evaluates DOM globals at import time (`const parser = new DOMParser()` in fragment-swap; `class ValOutlet extends HTMLElement`). Consequence: **`valence telemetry:aggregate` — which dynamic-imports the barrel — has been broken in node since `init.ts` landed.** Verified with `node -e "import('@valencets/telemetry')"` → `ReferenceError`.

Fixes:
- `core`: `DOMParser` constructed lazily (importable anywhere, DOM required at call time)
- `core`: new `./telemetry` subpath export — the engine (ring buffer, flush, delegation, consent) is import-clean in node
- `telemetry`: `init.ts` imports the engine subpath instead of the full client barrel; barrel now imports in plain node (test pins it)

### 2. Beacon endpoint buffered request bodies without any cap

`readRequestBody` waited for `end` forever and buffered unbounded streams. Now capped at 256 KB (sendBeacon browser caps are ~64 KB — anything past this is hostile): at the cap the read settles immediately with an empty body, which fails validation into the existing silent-accept 200 path. Test proves the handler answers **without waiting for stream end**.

### 3. The mount itself

- `telemetry-wiring.ts` (new): `maybeRegisterTelemetry(config, registerRoute, pool, log)` — mirrors the `maybeRegisterStores` pattern; registered as a custom route so `/api/telemetry` wins over the REST `/api/:slug` pattern
- `cli.ts`: mounted in both `runDev` and `runStart` (source-guard test pins both)

## Validation

- TDD: 4 RED→GREEN pairs (telemetry cap, core DOM-less imports, telemetry barrel, valence mount) + REFACTOR, reordered via rebase so every pair is adjacent; sequence check passes
- `@valencets/telemetry` 144/144, `@valencets/core` node-import suite green, valence wiring 5/5 (mount, disabled no-op, valid-beacon round trip, DNT respected + pool untouched, dev+prod source guard)
- `node -e "import('@valencets/telemetry')"` → OK (was: crash)
- `telemetry.api.md` updated (import path only); core `./telemetry` subpath is additive pre-freeze (#337 note)
- tsc, eslint, banned-patterns green