### PR TITLE
integrity(valence): mount the GraphQL endpoint graphql:true promises (#350)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -140,3 +140,9 @@ node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"
 `valence init` already writes a CSPRNG-minted secret into the scaffolded `.env`; the `.env.example` placeholder `change-me` is rejected by design so it can never be promoted to production unchanged.
 
 **Rotation semantics**: rotating `CMS_SECRET` invalidates every signed anonymous store session immediately — anonymous visitors get fresh (empty) session-scoped store buckets on next contact. This is by design: signed anonymous sessions are stateless and cannot be revoked individually (see `docs/STORES.md`). Authenticated `cms_session` logins are stored server-side and survive rotation. Rotate during a low-traffic window if anonymous carts/drafts matter to you.
+
+## GraphQL endpoint returns 401 or 404
+
+**404**: `graphql: true` must be set in `valence.config.ts`. The endpoint mounts at `POST /graphql` in both `valence dev` and `valence start`.
+
+**401**: the endpoint requires a validated `cms_session` cookie. The derived resolvers do not yet run per-collection access functions, so the whole endpoint inherits REST's auth-by-default posture — log in through the admin (or `POST /api/auth/login`) first and send the cookie with your requests. Request bodies are capped at 256 KB (413 beyond).

--- a/packages/graphql/src/__tests__/handler.test.ts
+++ b/packages/graphql/src/__tests__/handler.test.ts
@@ -139,6 +139,34 @@ describe('createGraphQLHandler', () => {
     })
   })
 
+  // #350 audit — the handler buffered request bodies without a cap and
+  // waited for 'end' forever. Once the cap is exceeded it must answer 413
+  // immediately instead of buffering an attacker's unbounded stream.
+  describe('body size cap', () => {
+    it('answers oversized bodies at the cap without waiting for the stream to end', async () => {
+      const schema = makeSimpleSchema()
+      const handler = createGraphQLHandler(schema)
+
+      const emitter = new EventEmitter() as IncomingMessage
+      emitter.method = 'POST'
+      emitter.headers = {}
+      emitter.url = '/graphql'
+      setTimeout(() => {
+        for (let i = 0; i < 30; i++) {
+          emitter.emit('data', Buffer.alloc(10_000, 120))
+        }
+        // no 'end' — the handler must have already answered
+      }, 0)
+
+      const { res, capture } = makeResponse()
+      await handler(emitter, res)
+
+      expect(capture.status).toBe(413)
+      const parsed = JSON.parse(capture.body) as { errors: Array<{ message: string }> }
+      expect(parsed.errors[0]!.message).toContain('too large')
+    }, 4000)
+  })
+
   describe('JSON body parsing', () => {
     it('returns 400 for non-JSON body', async () => {
       const schema = makeSimpleSchema()

--- a/packages/graphql/src/handler.ts
+++ b/packages/graphql/src/handler.ts
@@ -11,11 +11,37 @@ interface JsonErrorResponse {
 
 type JsonResponse = ExecutionResult | JsonErrorResponse
 
-function readBody (req: IncomingMessage): Promise<string> {
+// #350 audit — GraphQL documents are small; anything past this is hostile.
+// At the cap the read settles immediately so nothing buffers an
+// attacker's unbounded stream.
+const MAX_BODY_BYTES = 256 * 1024
+
+interface BodyRead {
+  readonly body: string
+  readonly tooLarge: boolean
+}
+
+function readBody (req: IncomingMessage): Promise<BodyRead> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => { chunks.push(chunk) })
-    req.on('end', () => { resolve(Buffer.concat(chunks).toString('utf-8')) })
+    let total = 0
+    let settled = false
+    const settle = (result: BodyRead): void => {
+      if (settled) return
+      settled = true
+      resolve(result)
+    }
+    req.on('data', (chunk: Buffer) => {
+      if (settled) return
+      total += chunk.length
+      if (total > MAX_BODY_BYTES) {
+        chunks.length = 0
+        settle({ body: '', tooLarge: true })
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => { settle({ body: Buffer.concat(chunks).toString('utf-8'), tooLarge: false }) })
     req.on('error', reject)
   })
 }
@@ -44,7 +70,14 @@ export function createGraphQLHandler (schema: GraphQLSchema): (req: IncomingMess
       return
     }
 
-    const rawBody = await readBody(req)
+    const bodyRead = await readBody(req)
+
+    if (bodyRead.tooLarge) {
+      sendJson(res, 413, { errors: [{ message: 'Request body too large.' }] })
+      return
+    }
+
+    const rawBody = bodyRead.body
 
     if (rawBody.trim() === '') {
       sendJson(res, 400, { errors: [{ message: 'Request body is required.' }] })

--- a/packages/valence/package.json
+++ b/packages/valence/package.json
@@ -25,6 +25,7 @@
     "@valencets/cms": "workspace:*",
     "@valencets/core": "workspace:*",
     "@valencets/db": "workspace:*",
+    "@valencets/graphql": "workspace:*",
     "@valencets/reactive": "workspace:*",
     "@valencets/resultkit": "^0.5.0",
     "@valencets/store": "workspace:*",

--- a/packages/valence/src/__tests__/graphql-wiring.test.ts
+++ b/packages/valence/src/__tests__/graphql-wiring.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { DbPool } from '@valencets/db'
+import { buildCms, collection, field } from '@valencets/cms'
+import type { CmsInstance } from '@valencets/cms'
+import { maybeRegisterGraphQL } from '../graphql-wiring.js'
+import type { RouteHandler } from '../define-config.js'
+
+// #350 — `graphql: true` was config-validated but nothing mounted
+// POST /graphql. The wiring mounts the derived schema, gated behind a
+// validated cms_session: the resolvers perform no per-collection access
+// checks yet, so the endpoint inherits REST's auth-by-default posture.
+
+function collectRoutes (): { registerRoute: (method: string, path: string, handler: RouteHandler) => void; routes: Map<string, RouteHandler> } {
+  const routes = new Map<string, RouteHandler>()
+  return {
+    registerRoute: (method, path, handler) => { routes.set(`${method} ${path}`, handler) },
+    routes
+  }
+}
+
+function mockPool (): DbPool {
+  const tagged = vi.fn(async () => [])
+  const sql = Object.assign(tagged, {
+    unsafe: vi.fn(async () => []),
+    json: (v: unknown) => v,
+    begin: vi.fn(async () => undefined)
+  })
+  return { sql } as unknown as DbPool
+}
+
+function makeCms (): CmsInstance {
+  const result = buildCms({
+    db: mockPool(),
+    secret: 'x'.repeat(32),
+    collections: [
+      collection({ slug: 'posts', fields: [field.text({ name: 'title', required: true })] })
+    ]
+  })
+  if (result.isErr()) return undefined as never
+  return result.value
+}
+
+function postReq (body: string, cookie?: string): IncomingMessage {
+  const emitter = new EventEmitter()
+  const req = Object.assign(emitter, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...(cookie !== undefined ? { cookie } : {}) },
+    url: '/graphql'
+  })
+  setTimeout(() => {
+    emitter.emit('data', Buffer.from(body))
+    emitter.emit('end')
+  }, 0)
+  return req as unknown as IncomingMessage
+}
+
+function mockRes (): ServerResponse & { _status: number; _body: string } {
+  const res = {
+    _status: 0,
+    _body: '',
+    headersSent: false,
+    writeHead (status: number) { res._status = status; return res },
+    setHeader () { return res },
+    end (body?: string) { res._body = body ?? ''; res.headersSent = true }
+  }
+  return res as unknown as ServerResponse & { _status: number; _body: string }
+}
+
+describe('maybeRegisterGraphQL', () => {
+  it('mounts POST /graphql when enabled', async () => {
+    const { registerRoute, routes } = collectRoutes()
+
+    const mounted = await maybeRegisterGraphQL(true, registerRoute, makeCms(), async () => 'user-1')
+
+    expect(mounted).toBe(true)
+    expect(routes.has('POST /graphql')).toBe(true)
+  })
+
+  it('mounts nothing when disabled or unset', async () => {
+    const { registerRoute, routes } = collectRoutes()
+
+    expect(await maybeRegisterGraphQL(undefined, registerRoute, makeCms(), async () => 'user-1')).toBe(false)
+    expect(await maybeRegisterGraphQL(false, registerRoute, makeCms(), async () => 'user-1')).toBe(false)
+    expect(routes.size).toBe(0)
+  })
+
+  it('rejects requests without a valid cms_session (auth-by-default)', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    await maybeRegisterGraphQL(true, registerRoute, makeCms(), async () => null)
+
+    const anonymous = mockRes()
+    await routes.get('POST /graphql')!(postReq('{"query":"{ __typename }"}'), anonymous, {})
+    expect(anonymous._status).toBe(401)
+    expect(JSON.parse(anonymous._body).errors[0].message).toContain('Unauthorized')
+
+    const staleSession = mockRes()
+    await routes.get('POST /graphql')!(postReq('{"query":"{ __typename }"}', 'cms_session=stale-token'), staleSession, {})
+    expect(staleSession._status).toBe(401)
+  })
+
+  it('executes queries for a validated session', async () => {
+    const { registerRoute, routes } = collectRoutes()
+    const validate = vi.fn(async () => 'user-1')
+    await maybeRegisterGraphQL(true, registerRoute, makeCms(), validate)
+
+    const res = mockRes()
+    await routes.get('POST /graphql')!(postReq('{"query":"{ __typename }"}', 'cms_session=valid-token'), res, {})
+
+    expect(validate).toHaveBeenCalledWith('valid-token')
+    expect(res._status).toBe(200)
+    expect(JSON.parse(res._body).data.__typename).toBe('Query')
+  })
+})
+
+describe('cli wiring', () => {
+  it('both runDev and runStart mount the graphql endpoint', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { join, dirname } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const source = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', 'cli.ts'),
+      'utf-8'
+    ).replace(/\r\n/g, '\n')
+
+    const mounts = source.match(/maybeRegisterGraphQL\(/g) ?? []
+    expect(mounts.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -9,7 +9,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { ResultAsync, fromThrowable } from '@valencets/resultkit'
 import { createPool, closePool, loadMigrations, runMigrations } from '@valencets/db'
 import type { DbConfig, DbPool } from '@valencets/db'
-import { buildCms } from '@valencets/cms'
+import { buildCms, validateSession } from '@valencets/cms'
 import type { RestRouteEntry } from '@valencets/cms'
 import { readLearnProgress, writeLearnProgress, createInitialProgress } from './learn/index.js'
 import { log } from './cli-utils.js'
@@ -17,6 +17,7 @@ import { generateConfigTemplate, generateSecret } from './config-template.js'
 import { validateProductionSecret } from './secret-guard.js'
 import { validateColumnNaming } from './migration-checks.js'
 import { maybeRegisterTelemetry } from './telemetry-wiring.js'
+import { maybeRegisterGraphQL } from './graphql-wiring.js'
 import { parseInitFlags, askWithDefault, confirmWithDefault, createDbInvocations, migrationTargets, initSummary, createPromptQueue, scaffoldDependencies } from './init-steps.js'
 import { landingPage } from './landing-page.js'
 import { loadEnvConfig, loadUserConfig, registerTsxLoader } from './config-loader.js'
@@ -819,6 +820,10 @@ async function runDev (): Promise<void> {
   // Mount beacon ingestion at the configured endpoint (#349)
   maybeRegisterTelemetry(loadedConfig.telemetry, registerRoute, pool, log)
 
+  // Mount the GraphQL endpoint when enabled (#350) — cms_session gated
+  await maybeRegisterGraphQL(loadedConfig.graphql, registerRoute, cms, (sessionId) =>
+    validateSession(sessionId, pool).match((userId) => userId, () => null), log)
+
   // Schema-driven generated route map (custom routes take priority)
   const generatedRoutes = generateCollectionRoutes(userConfig, loadedConfig.routes)
   const generatedRouteMap = buildGeneratedRouteMap(generatedRoutes, projectDir, storeHydrator)
@@ -1080,6 +1085,10 @@ export async function runStart (): Promise<void> {
 
   // Mount beacon ingestion at the configured endpoint (#349)
   maybeRegisterTelemetry(loadedConfig.telemetry, registerRoute, pool, log)
+
+  // Mount the GraphQL endpoint when enabled (#350) — cms_session gated
+  await maybeRegisterGraphQL(loadedConfig.graphql, registerRoute, cms, (sessionId) =>
+    validateSession(sessionId, pool).match((userId) => userId, () => null), log)
 
   // Schema-driven generated route map (custom routes take priority)
   const generatedRoutes = generateCollectionRoutes(userConfig, loadedConfig.routes)

--- a/packages/valence/src/config-loader.ts
+++ b/packages/valence/src/config-loader.ts
@@ -41,6 +41,8 @@ export interface UserConfig {
   readonly routes?: readonly RouteConfig[] | undefined
   // Store definitions — contain mutation server/client functions, only via direct import.
   readonly stores?: readonly import('@valencets/store').StoreInput[] | undefined
+  // Whether the GraphQL endpoint is enabled (#350).
+  readonly graphql?: boolean | undefined
 }
 
 export function loadEnvConfig (): DbConfig | null {
@@ -126,7 +128,8 @@ export async function loadUserConfig (): Promise<UserConfig | null> {
         // preserved via direct import — serialisation through the tsx subprocess would lose them.
         onServer: result.value?.onServer,
         routes: result.value?.routes,
-        stores: result.value?.stores
+        stores: result.value?.stores,
+        graphql: result.value?.graphql
       }
     }
     return null
@@ -150,7 +153,8 @@ async function loadViaSubprocess (configPath: string): Promise<UserConfig | null
     '        timestamps: c.timestamps, fields: c.fields',
     '      })),',
     '      admin: r.value.admin,',
-    '      telemetry: r.value.telemetry',
+    '      telemetry: r.value.telemetry,',
+    '      graphql: r.value.graphql',
     '    }));',
     '  }',
     '})',
@@ -178,11 +182,11 @@ async function loadViaSubprocess (configPath: string): Promise<UserConfig | null
 
   const parseResult = safeJsonParseConfig(output)
   if (parseResult.isErr() || parseResult.value === null) return null
-  const parsed = parseResult.value as { collections: import('@valencets/cms').CollectionConfig[]; admin?: UserConfig['admin']; telemetry?: UserConfig['telemetry'] }
+  const parsed = parseResult.value as { collections: import('@valencets/cms').CollectionConfig[]; admin?: UserConfig['admin']; telemetry?: UserConfig['telemetry']; graphql?: boolean }
 
   // Re-hydrate through collection() to get proper CollectionConfig objects.
   // onServer and routes cannot be recovered from the subprocess — functions are not serialisable.
   const { collection: col } = await import('@valencets/cms')
   const collections = parsed.collections.map((c) => col(c))
-  return { collections, admin: parsed.admin, telemetry: parsed.telemetry }
+  return { collections, admin: parsed.admin, telemetry: parsed.telemetry, graphql: parsed.graphql }
 }

--- a/packages/valence/src/define-config.ts
+++ b/packages/valence/src/define-config.ts
@@ -113,7 +113,10 @@ export interface ValenceConfig {
   // Schema-driven public routes. Handlers are not Zod-serializable, so
   // routes are extracted before validation and re-attached after resolution.
   readonly routes?: readonly RouteConfig[] | undefined
-  // Enable the GraphQL endpoint at POST /graphql. Requires @valencets/graphql installed.
+  // Enable the GraphQL endpoint at POST /graphql (#350). The endpoint is
+  // gated behind a validated cms_session — resolvers perform no
+  // per-collection access checks yet, so it inherits REST's
+  // auth-by-default posture.
   readonly graphql?: boolean | undefined
 }
 

--- a/packages/valence/src/graphql-wiring.ts
+++ b/packages/valence/src/graphql-wiring.ts
@@ -1,0 +1,69 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { ResultAsync } from '@valencets/resultkit'
+import { parseCookie } from '@valencets/cms'
+import type { CmsInstance } from '@valencets/cms'
+import type { RouteHandler } from './define-config.js'
+
+/**
+ * #350 — mount the GraphQL endpoint the config promises. `graphql: true`
+ * was validated by defineConfig but nothing mounted POST /graphql.
+ *
+ * Auth posture: the derived resolvers perform no per-collection access
+ * checks yet, so the whole endpoint requires a validated cms_session —
+ * the same auth-by-default stance REST takes for collections without
+ * access functions. Per-collection access in resolvers is future work.
+ *
+ * @valencets/graphql loads lazily so graphql-js stays out of boots that
+ * never enable it.
+ */
+export async function maybeRegisterGraphQL (
+  enabled: boolean | undefined,
+  registerRoute: (method: string, path: string, handler: RouteHandler) => void,
+  cms: CmsInstance,
+  validateCmsSession: (sessionId: string) => Promise<string | null>,
+  logFn?: (msg: string) => void
+): Promise<boolean> {
+  if (enabled !== true) return false
+
+  const imported = await ResultAsync.fromPromise(
+    import('@valencets/graphql'),
+    (e) => e
+  )
+  if (imported.isErr()) {
+    const cause = imported.error
+    if (logFn) logFn(`graphql: true but @valencets/graphql failed to load: ${cause instanceof Error ? cause.message : 'unknown'}`)
+    return false
+  }
+
+  const { createGraphQLRoutes } = imported.value
+  const routes = createGraphQLRoutes(cms)
+  const entry = routes.get('/graphql')
+  const handler = entry?.POST
+  if (handler === undefined) {
+    if (logFn) logFn('graphql: createGraphQLRoutes returned no POST /graphql handler')
+    return false
+  }
+
+  const sendUnauthorized = (res: ServerResponse): void => {
+    const body = JSON.stringify({ errors: [{ message: 'Unauthorized: a valid cms_session is required.' }] })
+    res.writeHead(401, { 'Content-Type': 'application/json', 'Content-Length': String(Buffer.byteLength(body)) })
+    res.end(body)
+  }
+
+  registerRoute('POST', '/graphql', async (req: IncomingMessage, res: ServerResponse) => {
+    const sessionId = parseCookie(req.headers.cookie ?? '', 'cms_session')
+    if (!sessionId) {
+      sendUnauthorized(res)
+      return
+    }
+    const userId = await validateCmsSession(sessionId)
+    if (userId === null) {
+      sendUnauthorized(res)
+      return
+    }
+    await handler(req, res, {})
+  })
+
+  if (logFn) logFn('GraphQL endpoint mounted at POST /graphql (cms_session required)')
+  return true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       '@valencets/db':
         specifier: workspace:*
         version: link:../db
+      '@valencets/graphql':
+        specifier: workspace:*
+        version: link:../graphql
       '@valencets/reactive':
         specifier: workspace:*
         version: link:../reactive
@@ -2616,6 +2619,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}


### PR DESCRIPTION
Closes #350.

## What

`graphql: true` was accepted and resolved by `defineConfig` — and did nothing. No code in `valence` imported `@valencets/graphql` or mounted `POST /graphql`. Now:

- **`graphql-wiring.ts` (new)**: `maybeRegisterGraphQL(enabled, registerRoute, cms, validateCmsSession, log)` — lazily imports `@valencets/graphql` (graphql-js stays out of boots that never enable it), reuses the package's existing `createGraphQLRoutes(cms)`, and mounts the handler in both `runDev` and `runStart` (source-guard test pins both).
- **Auth posture decided + documented**: the derived resolvers perform no per-collection access checks yet, so the whole endpoint requires a **validated `cms_session`** — the same auth-by-default stance REST takes for collections without access functions. 401 with a GraphQL errors envelope otherwise. Per-collection access in resolvers is future work (noted for the freeze review #337).
- **`UserConfig` carries `graphql`** through both config-loader paths (direct import and the tsx subprocess serialization — it previously dropped the flag).
- **Body cap (graphql package)**: `readBody` buffered unbounded streams and waited for `end` forever; now 256 KB, answering **413 at the cap without waiting for stream end** (same treatment as the beacon endpoint in #360).
- `@valencets/graphql` added to valence dependencies (`workspace:*`) — it's the framework's own package and the config has promised it since the flag shipped.

## Validation

- TDD: 2 RED→GREEN pairs (graphql cap, valence mount) + REFACTOR; sequence check passes
- 6 new tests: mount/no-op, anonymous + stale-session → 401 envelope, validated session executes `{ __typename }` → 200, dev+prod source guard, 413-at-cap without stream end
- `@valencets/graphql` 102/102, valence wiring suites 59/59
- `docs/TROUBLESHOOTING.md` + `defineConfig` comment updated; api reports unchanged
- tsc, eslint, banned-patterns green