### PR TITLE
feat(valence): optional-everything CLI — a Valence app is routes + pages by default

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -146,3 +146,22 @@ node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"
 **404**: `graphql: true` must be set in `valence.config.ts`. The endpoint mounts at `POST /graphql` in both `valence dev` and `valence start`.
 
 **401**: the endpoint requires a validated `cms_session` cookie. The derived resolvers do not yet run per-collection access functions, so the whole endpoint inherits REST's auth-by-default posture — log in through the admin (or `POST /api/auth/login`) first and send the cookie with your requests. Request bodies are capped at 256 KB (413 beyond).
+
+## What does `valence dev` / `valence start` actually need?
+
+Nothing you didn't ask for. A Valence app is routes + pages by default; the boot derives every mount from `valence.config.ts`:
+
+| Config declares | What boots | Needs a database? | Needs CMS_SECRET in prod? |
+|---|---|---|---|
+| nothing / `routes` / `src/pages` | routes, pages, static files | no | no |
+| `stores` (page scope) | typed client signals | no | no |
+| `stores` (session/global, in-memory) | store endpoints + SSE | no | yes |
+| `stores` (persist / user scope) | postgres-backed stores | **yes** | yes |
+| `collections` | Local API + REST | **yes** | yes |
+| `collections` + `admin` | + admin panel | **yes** | yes |
+| `graphql: true` (+ collections) | POST /graphql | **yes** | yes |
+| `telemetry.enabled` | beacon ingestion + analytics | **yes** | — |
+
+When a feature needs a database and none is configured, the boot refuses and **names the feature**: `collections + telemetry need a database — add a db section to valence.config.ts or DB_* variables to .env.` The config file's `db` section wins over `DB_*` env vars; both are optional for database-less apps.
+
+`valence init` mirrors this: answer "no" to the CMS prompt (or pass `--minimal`) for a routes-and-pages scaffold with no database, migrations, or admin. CMS projects get a `docker-compose.yml` wired to your answers, connectivity is verified before migrations run, and choosing the admin panel mints your first admin user during init (credentials printed once).

--- a/packages/valence/src/__tests__/boot-gating.test.ts
+++ b/packages/valence/src/__tests__/boot-gating.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// The optional-everything boot: `valence start` derives what to mount from
+// the config alone. A routes-only app boots with no database, no CMS, no
+// admin, and no CMS_SECRET; database features refuse to boot without a
+// database and NAME the feature that demanded it.
+
+const listen = vi.fn((_port: number, cb?: () => void) => { if (cb) cb(); return fakeServer })
+const fakeServer = { listen, close: vi.fn() }
+
+vi.mock('node:http', () => ({
+  createServer: vi.fn(() => fakeServer)
+}))
+
+vi.mock('../config-loader.js', () => ({
+  registerTsxLoader: vi.fn(async () => {}),
+  loadEnvConfig: vi.fn(() => null),
+  loadUserConfig: vi.fn(async () => ({ collections: [] }))
+}))
+
+vi.mock('../codegen/regenerate.js', () => ({
+  ensureGeneratedModules: vi.fn(async () => {}),
+  regenerateFromConfig: vi.fn()
+}))
+
+class ExitError extends Error {
+  constructor (public readonly code: number) {
+    super(`process.exit(${code})`)
+  }
+}
+
+describe('runStart — optional-everything boot', () => {
+  const originalExit = process.exit
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exit = ((code: number) => { throw new ExitError(code) }) as never
+    delete process.env.CMS_SECRET
+  })
+
+  afterEach(() => {
+    process.exit = originalExit
+    if (originalEnv.CMS_SECRET !== undefined) process.env.CMS_SECRET = originalEnv.CMS_SECRET
+  })
+
+  it('boots a routes-only app with no database and no CMS_SECRET', async () => {
+    const { loadUserConfig } = await import('../config-loader.js')
+    vi.mocked(loadUserConfig).mockResolvedValueOnce({
+      collections: [],
+      routes: [{ path: '/api/hello', loader: async () => ({ data: { ok: true } }) }]
+    })
+
+    const { runStart } = await import('../cli.js')
+
+    let exitCode: number | undefined
+    const errors: string[] = []
+    const originalError = console.error
+    console.error = (...args: string[]) => { errors.push(args.join(' ')) }
+    try {
+      await runStart()
+    } catch (err) {
+      if (err instanceof ExitError) exitCode = err.code
+    }
+    console.error = originalError
+
+    expect(exitCode).toBeUndefined()
+    expect(listen).toHaveBeenCalled()
+    expect(errors).toHaveLength(0)
+  })
+
+  it('refuses to boot collections without a database, naming the feature', async () => {
+    process.env.CMS_SECRET = 'f'.repeat(64)
+    const { loadUserConfig } = await import('../config-loader.js')
+    vi.mocked(loadUserConfig).mockResolvedValueOnce({
+      collections: [{ slug: 'posts', fields: [], timestamps: true }] as never
+    })
+
+    const { runStart } = await import('../cli.js')
+
+    let exitCode: number | undefined
+    const errors: string[] = []
+    const originalError = console.error
+    console.error = (...args: string[]) => { errors.push(args.join(' ')) }
+    try {
+      await runStart()
+    } catch (err) {
+      if (err instanceof ExitError) exitCode = err.code
+    }
+    console.error = originalError
+
+    expect(exitCode).toBe(1)
+    const message = errors.join(' ')
+    expect(message).toContain('collections')
+    expect(message).toContain('database')
+  })
+})
+
+describe('boot gating source guards', () => {
+  function cliSource (): string {
+    return readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', 'cli.ts'),
+      'utf-8'
+    ).replace(/\r\n/g, '\n')
+  }
+
+  it('both pipelines gate the admin panel behind the boot plan', () => {
+    const mounts = cliSource().match(/plan\.mountAdmin/g) ?? []
+    expect(mounts.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('dev provisions the dev database only when the plan needs it', () => {
+    const source = cliSource()
+    const devBody = source.slice(source.indexOf('async function runDev'), source.indexOf('// -- start --'))
+    const planAt = devBody.indexOf('planBoot(')
+    const provisionAt = devBody.indexOf('ensureDevDatabase(')
+    expect(planAt).toBeGreaterThan(-1)
+    expect(provisionAt).toBeGreaterThan(planAt)
+  })
+
+  it('the secret guard runs only when the plan requires a secret', () => {
+    const guards = cliSource().match(/plan\.requiresSecret/g) ?? []
+    expect(guards.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/packages/valence/src/__tests__/boot-gating.test.ts
+++ b/packages/valence/src/__tests__/boot-gating.test.ts
@@ -112,13 +112,15 @@ describe('boot gating source guards', () => {
     expect(mounts.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('dev provisions the dev database only when the plan needs it', () => {
+  it('the database provisioner gates on the plan before touching infrastructure', () => {
     const source = cliSource()
-    const devBody = source.slice(source.indexOf('async function runDev'), source.indexOf('// -- start --'))
-    const planAt = devBody.indexOf('planBoot(')
-    const provisionAt = devBody.indexOf('ensureDevDatabase(')
-    expect(planAt).toBeGreaterThan(-1)
-    expect(provisionAt).toBeGreaterThan(planAt)
+    const fnStart = source.indexOf('async function provisionDatabase')
+    expect(fnStart).toBeGreaterThan(-1)
+    const fnBody = source.slice(fnStart, source.indexOf('async function buildCmsIfPlanned'))
+    const gateAt = fnBody.indexOf('needsDatabase')
+    const provisionAt = fnBody.indexOf('ensureDevDatabase(')
+    expect(gateAt).toBeGreaterThan(-1)
+    expect(provisionAt).toBeGreaterThan(gateAt)
   })
 
   it('the secret guard runs only when the plan requires a secret', () => {

--- a/packages/valence/src/__tests__/boot-plan.test.ts
+++ b/packages/valence/src/__tests__/boot-plan.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { planBoot } from '../boot-plan.js'
+
+// The optional-everything contract: a Valence app is routes + pages by
+// default. CMS, admin, database, telemetry, GraphQL, and stores are each
+// opt-in — the boot plan derives what to mount and WHY a database is
+// needed (so refusals can name the feature that demanded it).
+
+describe('planBoot — minimal app', () => {
+  it('an empty config mounts nothing and needs nothing', () => {
+    const plan = planBoot({ collections: [] })
+
+    expect(plan.mountCms).toBe(false)
+    expect(plan.mountAdmin).toBe(false)
+    expect(plan.mountGraphql).toBe(false)
+    expect(plan.mountTelemetry).toBe(false)
+    expect(plan.registerStores).toBe(false)
+    expect(plan.needsDatabase).toBe(false)
+    expect(plan.databaseReasons).toEqual([])
+    expect(plan.requiresSecret).toBe(false)
+  })
+
+  it('routes-only apps need no database and no secret', () => {
+    const plan = planBoot({ collections: [], routes: [{ path: '/hello' }] })
+
+    expect(plan.needsDatabase).toBe(false)
+    expect(plan.requiresSecret).toBe(false)
+  })
+})
+
+describe('planBoot — CMS', () => {
+  it('collections mount the CMS and demand a database', () => {
+    const plan = planBoot({ collections: [{ slug: 'posts' }] })
+
+    expect(plan.mountCms).toBe(true)
+    expect(plan.needsDatabase).toBe(true)
+    expect(plan.databaseReasons).toContain('collections')
+    expect(plan.requiresSecret).toBe(true)
+  })
+
+  it('the admin panel mounts only when the admin section is present', () => {
+    const headless = planBoot({ collections: [{ slug: 'posts' }] })
+    expect(headless.mountAdmin).toBe(false)
+
+    const withAdmin = planBoot({ collections: [{ slug: 'posts' }], admin: { requireAuth: true } })
+    expect(withAdmin.mountAdmin).toBe(true)
+  })
+
+  it('an admin section without collections mounts no admin', () => {
+    const plan = planBoot({ collections: [], admin: { requireAuth: true } })
+    expect(plan.mountAdmin).toBe(false)
+  })
+
+  it('graphql mounts only alongside the CMS', () => {
+    expect(planBoot({ collections: [{ slug: 'posts' }], graphql: true }).mountGraphql).toBe(true)
+    expect(planBoot({ collections: [], graphql: true }).mountGraphql).toBe(false)
+    expect(planBoot({ collections: [{ slug: 'posts' }] }).mountGraphql).toBe(false)
+  })
+})
+
+describe('planBoot — telemetry', () => {
+  it('enabled telemetry demands a database', () => {
+    const plan = planBoot({ collections: [], telemetry: { enabled: true } })
+
+    expect(plan.mountTelemetry).toBe(true)
+    expect(plan.needsDatabase).toBe(true)
+    expect(plan.databaseReasons).toContain('telemetry')
+  })
+
+  it('disabled telemetry demands nothing', () => {
+    const plan = planBoot({ collections: [], telemetry: { enabled: false } })
+
+    expect(plan.mountTelemetry).toBe(false)
+    expect(plan.needsDatabase).toBe(false)
+  })
+})
+
+describe('planBoot — stores', () => {
+  it('in-memory stores need no database but do need the signing secret', () => {
+    const plan = planBoot({ collections: [], stores: [{ slug: 'cart', scope: 'session' }] })
+
+    expect(plan.registerStores).toBe(true)
+    expect(plan.needsDatabase).toBe(false)
+    expect(plan.requiresSecret).toBe(true)
+  })
+
+  it('page-scoped stores need neither database nor secret', () => {
+    const plan = planBoot({ collections: [], stores: [{ slug: 'ui', scope: 'page' }] })
+
+    expect(plan.registerStores).toBe(true)
+    expect(plan.needsDatabase).toBe(false)
+    expect(plan.requiresSecret).toBe(false)
+  })
+
+  it('persisted and user-scoped stores demand a database', () => {
+    const persisted = planBoot({ collections: [], stores: [{ slug: 'drafts', scope: 'session', persist: true }] })
+    expect(persisted.needsDatabase).toBe(true)
+    expect(persisted.databaseReasons).toContain('persisted stores')
+
+    const userScoped = planBoot({ collections: [], stores: [{ slug: 'prefs', scope: 'user' }] })
+    expect(userScoped.needsDatabase).toBe(true)
+    expect(userScoped.databaseReasons).toContain('persisted stores')
+  })
+})
+
+describe('planBoot — combined reasons', () => {
+  it('names every feature that demanded the database', () => {
+    const plan = planBoot({
+      collections: [{ slug: 'posts' }],
+      telemetry: { enabled: true },
+      stores: [{ slug: 'prefs', scope: 'user' }]
+    })
+
+    expect(plan.needsDatabase).toBe(true)
+    expect(plan.databaseReasons).toEqual(['collections', 'telemetry', 'persisted stores'])
+  })
+})

--- a/packages/valence/src/__tests__/cli-start.test.ts
+++ b/packages/valence/src/__tests__/cli-start.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('../config-loader.js', () => ({
   registerTsxLoader: vi.fn(async () => {}),
-  loadEnvConfig: vi.fn(() => ({
-    host: 'localhost',
-    port: 5432,
-    database: 'test',
-    user: 'test',
-    password: 'test'
-  })),
-  loadUserConfig: vi.fn(async () => null)
+  // No database anywhere: tests that pass the secret guard stop at the
+  // db-refusal gate instead of touching real infrastructure.
+  loadEnvConfig: vi.fn(() => null),
+  // Collections make the boot plan require a secret — the guard must run
+  // before anything resolves a database.
+  loadUserConfig: vi.fn(async () => ({
+    collections: [{ slug: 'posts', fields: [], timestamps: true }]
+  }))
 }))
 
 class ExitError extends Error {
@@ -103,7 +103,7 @@ describe('runStart CMS_SECRET guard', () => {
     expect(errors.some((e) => e.includes('CMS_SECRET'))).toBe(true)
   })
 
-  it('boots past the secret guard with a strong secret (fails later on config, not CMS_SECRET)', async () => {
+  it('boots past the secret guard with a strong secret (fails later on the CMS, not CMS_SECRET)', async () => {
     process.env.CMS_SECRET = 'f'.repeat(64)
     const errors: string[] = []
     const originalError = console.error
@@ -124,6 +124,6 @@ describe('runStart CMS_SECRET guard', () => {
 
     expect(exitCode).toBe(1)
     expect(errors.some((e) => e.includes('CMS_SECRET'))).toBe(false)
-    expect(errors.some((e) => e.includes('valence.config.ts'))).toBe(true)
+    expect(errors.some((e) => e.includes('database'))).toBe(true)
   })
 })

--- a/packages/valence/src/__tests__/define-config.test.ts
+++ b/packages/valence/src/__tests__/define-config.test.ts
@@ -25,10 +25,10 @@ describe('defineConfig', () => {
   it('resolved config has db pool settings with defaults', () => {
     const result = defineConfig(minimalConfig)
     const resolved = result.unwrap()
-    expect(resolved.db.max).toBe(10)
-    expect(resolved.db.idle_timeout).toBe(30)
-    expect(resolved.db.connect_timeout).toBe(10)
-    expect(resolved.db.sslmode).toBe('disable')
+    expect(resolved.db?.max).toBe(10)
+    expect(resolved.db?.idle_timeout).toBe(30)
+    expect(resolved.db?.connect_timeout).toBe(10)
+    expect(resolved.db?.sslmode).toBe('disable')
   })
 
   it('resolved config has server host defaulting to 0.0.0.0', () => {
@@ -37,17 +37,49 @@ describe('defineConfig', () => {
     expect(resolved.server.host).toBe('0.0.0.0')
   })
 
-  it('returns Err for missing db', () => {
-    const result = defineConfig({ server: { port: 3000 }, collections: [] } as never)
-    expect(result.isErr()).toBe(true)
-  })
+  // The optional-everything contract: a Valence app is routes + pages by
+  // default. db, server, and collections are all optional — database
+  // features enforce their requirement at boot, with named reasons.
+  describe('optional-everything', () => {
+    it('accepts a completely empty config', () => {
+      const result = defineConfig({})
+      expect(result.isOk()).toBe(true)
+      const resolved = result.unwrap()
+      expect(resolved.db).toBeUndefined()
+      expect(resolved.collections).toEqual([])
+      expect(resolved.server.port).toBe(3000)
+      expect(resolved.server.host).toBe('0.0.0.0')
+    })
 
-  it('returns Err for missing server', () => {
-    const result = defineConfig({
-      db: { host: 'localhost', port: 5432, database: 'x', username: 'x', password: 'x' },
-      collections: []
-    } as never)
-    expect(result.isErr()).toBe(true)
+    it('accepts a routes-only config with no db, server, or collections', () => {
+      const result = defineConfig({
+        routes: [{ path: '/hello', loader: async () => ({ data: { ok: true } }) }]
+      })
+      expect(result.isOk()).toBe(true)
+      const resolved = result.unwrap()
+      expect(resolved.routes).toHaveLength(1)
+      expect(resolved.db).toBeUndefined()
+    })
+
+    it('accepts collections without a db section — the database may come from .env at boot', () => {
+      const result = defineConfig({
+        collections: [{ slug: 'posts', fields: [{ type: 'text', name: 'title' }], timestamps: true } as never]
+      })
+      expect(result.isOk()).toBe(true)
+    })
+
+    it('accepts a server section with only a host', () => {
+      const result = defineConfig({ server: { host: '127.0.0.1' } })
+      expect(result.isOk()).toBe(true)
+      const resolved = result.unwrap()
+      expect(resolved.server.port).toBe(3000)
+      expect(resolved.server.host).toBe('127.0.0.1')
+    })
+
+    it('still validates the db section when present', () => {
+      const result = defineConfig({ db: { host: '', port: 5432, database: 'x', username: 'x', password: 'x' } })
+      expect(result.isErr()).toBe(true)
+    })
   })
 
   it('accepts optional telemetry config', () => {

--- a/packages/valence/src/__tests__/init-optional.test.ts
+++ b/packages/valence/src/__tests__/init-optional.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { writeFile } from 'node:fs/promises'
+import { run } from '../cli.js'
+
+// The optional-everything init: a Valence app is routes + pages by
+// default. The CMS (database, collections, REST, admin) is opt-in — and
+// the CLI scaffolds a Valence app only, no third-party framework choices.
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(async () => {}),
+  mkdir: vi.fn(async () => undefined)
+}))
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(() => Buffer.from('')),
+  execFileSync: vi.fn(() => Buffer.from(''))
+}))
+
+const mockedWriteFile = vi.mocked(writeFile)
+
+function getWrittenFile (filename: string): string {
+  const call = mockedWriteFile.mock.calls.find(c => String(c[0]).endsWith(filename))
+  if (!call) throw new Error(`File ${filename} was not written`)
+  return String(call[1])
+}
+
+function wasWritten (filename: string): boolean {
+  return mockedWriteFile.mock.calls.some(c => String(c[0]).endsWith(filename))
+}
+
+describe('minimal init (--minimal)', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('scaffolds a config without db, collections, or admin', async () => {
+    await run(['init', 'my-site', '-y', '--minimal'])
+    const config = getWrittenFile('valence.config.ts')
+    expect(config).toContain('defineConfig')
+    expect(config).not.toContain('db:')
+    expect(config).not.toContain('collection(')
+    expect(config).not.toContain('admin:')
+    expect(config).toContain('routes:')
+  })
+
+  it('writes no migrations and no docker-compose', async () => {
+    await run(['init', 'my-site', '-y', '--minimal'])
+    expect(wasWritten('001-init.sql')).toBe(false)
+    expect(wasWritten('docker-compose.yml')).toBe(false)
+  })
+
+  it('writes an .env without database variables but with a CSPRNG secret', async () => {
+    await run(['init', 'my-site', '-y', '--minimal'])
+    const env = getWrittenFile('.env')
+    expect(env).not.toContain('DB_HOST')
+    expect(env).not.toContain('DB_PASSWORD')
+    expect(env).toMatch(/CMS_SECRET=[0-9a-f]{64}/)
+    expect(env).toContain('PORT=')
+  })
+
+  it('scaffolds a starter page instead of the CMS source tree', async () => {
+    await run(['init', 'my-site', '-y', '--minimal'])
+    expect(wasWritten('index.html')).toBe(true)
+  })
+})
+
+describe('the CLI builds Valence apps only', () => {
+  it('cli source offers no third-party framework choices', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { join, dirname } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const source = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', 'cli.ts'),
+      'utf-8'
+    )
+    expect(source).not.toMatch(/astro/i)
+    expect(source).not.toMatch(/frontend framework/i)
+    expect(source).not.toMatch(/react/i)
+  })
+})
+
+describe('cms init provisions the database properly', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('writes a docker-compose.yml so postgres can be stood up when absent', async () => {
+    await run(['init', 'test-app', '-y', '--no-db', '--no-migrate', '--no-seed'])
+    const compose = getWrittenFile('docker-compose.yml')
+    expect(compose).toContain('postgres:16')
+    expect(compose).toContain('POSTGRES_DB: test_app')
+    expect(compose).toContain('POSTGRES_USER: postgres')
+  })
+
+  it('keeps the full CMS scaffold when the CMS is chosen', async () => {
+    await run(['init', 'test-app', '-y'])
+    const config = getWrittenFile('valence.config.ts')
+    expect(config).toContain("slug: 'posts'")
+    expect(config).toContain('admin:')
+    expect(wasWritten('001-init.sql')).toBe(true)
+  })
+})

--- a/packages/valence/src/__tests__/init-steps.test.ts
+++ b/packages/valence/src/__tests__/init-steps.test.ts
@@ -50,6 +50,11 @@ describe('parseInitFlags', () => {
     expect(flags.noSeed).toBe(true)
     expect(flags.useDefaults).toBe(false)
   })
+
+  it('recognizes --minimal for a CMS-less scaffold', () => {
+    expect(parseInitFlags(['--minimal']).minimal).toBe(true)
+    expect(parseInitFlags(['my-app', '-y']).minimal).toBe(false)
+  })
 })
 
 describe('EOF-safe prompts', () => {
@@ -131,6 +136,22 @@ describe('initSummary', () => {
     expect(summary).not.toContain('Your project is ready')
     expect(summary).toContain('database creation failed')
     expect(summary).toContain('migrations failed')
+  })
+
+  it('omits the admin URL for CMS-less projects', () => {
+    const summary = initSummary('my-site', 3000, [], false, { includeCms: false })
+    expect(summary).not.toContain('Admin:')
+    expect(summary).toContain('Site:')
+  })
+
+  it('prints minted admin credentials exactly once when init created the user', () => {
+    const summary = initSummary('my-app', 3000, [], false, {
+      includeCms: true,
+      adminCredentials: { email: 'admin@localhost', password: 'generated-pw-123' }
+    })
+    expect(summary).toContain('admin@localhost')
+    expect(summary).toContain('generated-pw-123')
+    expect(summary).toContain('Admin:')
   })
 })
 

--- a/packages/valence/src/__tests__/postgres-setup.test.ts
+++ b/packages/valence/src/__tests__/postgres-setup.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { generateDockerCompose, verifyDatabaseConnection, createAdminUser } from '../postgres-setup.js'
+import type { DbPool } from '@valencets/db'
+
+// CMS init must set postgres up properly: a compose file so the database
+// can be stood up when absent, connectivity verified before claiming
+// success, and the admin user minted during init when the panel is chosen.
+
+const ANSWERS = { dbName: 'my_app', dbHost: 'localhost', dbPort: '5432', dbUser: 'postgres', dbPassword: 'hunter2' }
+
+describe('generateDockerCompose', () => {
+  it('emits a postgres 16 service wired to the init answers', () => {
+    const compose = generateDockerCompose(ANSWERS)
+    expect(compose).toContain('postgres:16')
+    expect(compose).toContain('POSTGRES_DB: my_app')
+    expect(compose).toContain('POSTGRES_USER: postgres')
+    expect(compose).toContain('POSTGRES_PASSWORD: hunter2')
+    expect(compose).toContain('"5432:5432"')
+    expect(compose).toContain('volumes:')
+  })
+
+  it('maps a custom host port onto the container port', () => {
+    const compose = generateDockerCompose({ ...ANSWERS, dbPort: '55432' })
+    expect(compose).toContain('"55432:5432"')
+  })
+})
+
+describe('verifyDatabaseConnection', () => {
+  function fakeDeps (behavior: 'ok' | 'reject') {
+    const sql = Object.assign(
+      vi.fn(() => behavior === 'ok' ? Promise.resolve([{ one: 1 }]) : Promise.reject(new Error('ECONNREFUSED'))),
+      { unsafe: vi.fn(), begin: vi.fn(), end: vi.fn(async () => undefined) }
+    )
+    const pool = { sql } as unknown as DbPool
+    return {
+      deps: {
+        createPool: vi.fn(() => pool),
+        closePool: vi.fn(() => ({ match: (okFn: () => void) => { okFn() } }))
+      },
+      sql
+    }
+  }
+
+  it('answers ok when SELECT 1 round-trips', async () => {
+    const { deps } = fakeDeps('ok')
+    const result = await verifyDatabaseConnection(
+      { host: 'localhost', port: 5432, database: 'x', username: 'u', password: 'p', max: 1, idle_timeout: 5, connect_timeout: 3 },
+      deps as never
+    )
+    expect(result.isOk()).toBe(true)
+  })
+
+  it('answers err with the driver message when the database is unreachable', async () => {
+    const { deps } = fakeDeps('reject')
+    const result = await verifyDatabaseConnection(
+      { host: 'localhost', port: 5432, database: 'x', username: 'u', password: 'p', max: 1, idle_timeout: 5, connect_timeout: 3 },
+      deps as never
+    )
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.message).toContain('ECONNREFUSED')
+    }
+  })
+})
+
+describe('createAdminUser', () => {
+  function capturePool () {
+    const unsafe = vi.fn(async () => [{ id: 'u1' }])
+    const sql = Object.assign(vi.fn(), { unsafe, begin: vi.fn() })
+    return { pool: { sql } as unknown as DbPool, unsafe }
+  }
+
+  it('inserts an admin with an argon2id hash, never the plaintext password', async () => {
+    const { pool, unsafe } = capturePool()
+
+    const result = await createAdminUser(pool, { email: 'admin@example.com', password: 'correct horse battery', name: 'Admin' })
+
+    expect(result.isOk()).toBe(true)
+    expect(unsafe).toHaveBeenCalledTimes(1)
+    const [text, params] = unsafe.mock.calls[0]! as [string, readonly string[]]
+    expect(text).toContain('INSERT INTO "users"')
+    expect(text).toContain('$1')
+    expect(params).toContain('admin@example.com')
+    expect(params).toContain('Admin')
+    expect(params).toContain('admin')
+    expect(params.some(p => String(p).startsWith('$argon2id$'))).toBe(true)
+    expect(params).not.toContain('correct horse battery')
+  })
+
+  it('maps insert failures into an error instead of throwing', async () => {
+    const unsafe = vi.fn(async () => Promise.reject(new Error('duplicate key')))
+    const sql = Object.assign(vi.fn(), { unsafe, begin: vi.fn() })
+
+    const result = await createAdminUser({ sql } as unknown as DbPool, { email: 'a@b.c', password: 'x'.repeat(12), name: 'A' })
+
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.message).toContain('duplicate key')
+    }
+  })
+})

--- a/packages/valence/src/boot-plan.ts
+++ b/packages/valence/src/boot-plan.ts
@@ -1,0 +1,64 @@
+/**
+ * The optional-everything contract: a Valence app is routes + pages by
+ * default. CMS, admin panel, database, telemetry, GraphQL, and stores are
+ * each opt-in, derived from the config alone. The plan names WHY a
+ * database is required so boot refusals can point at the exact feature
+ * instead of demanding infrastructure the app never asked for.
+ */
+
+export interface BootPlanInput {
+  readonly collections: ReadonlyArray<{ readonly slug: string }>
+  readonly admin?: { readonly requireAuth?: boolean | undefined } | undefined
+  readonly telemetry?: { readonly enabled: boolean } | undefined
+  readonly stores?: ReadonlyArray<{ readonly slug: string, readonly scope: string, readonly persist?: boolean | undefined }> | undefined
+  readonly graphql?: boolean | undefined
+  readonly routes?: ReadonlyArray<{ readonly path: string }> | undefined
+}
+
+export interface BootPlan {
+  /** Collections exist → Local API + REST mount. */
+  readonly mountCms: boolean
+  /** Admin panel mounts only when the config has an admin section AND collections. */
+  readonly mountAdmin: boolean
+  /** GraphQL derives its schema from collections — no CMS, no endpoint. */
+  readonly mountGraphql: boolean
+  readonly mountTelemetry: boolean
+  readonly registerStores: boolean
+  /** True when any configured feature cannot run without postgres. */
+  readonly needsDatabase: boolean
+  /** The features that demanded the database, for accurate refusals. */
+  readonly databaseReasons: readonly string[]
+  /** CMS sessions and non-page store scopes sign tokens with CMS_SECRET. */
+  readonly requiresSecret: boolean
+}
+
+function isPersistedStore (store: { readonly scope: string, readonly persist?: boolean | undefined }): boolean {
+  return store.scope === 'user' || (store.persist === true && store.scope !== 'page')
+}
+
+export function planBoot (input: BootPlanInput): BootPlan {
+  const mountCms = input.collections.length > 0
+  const mountAdmin = mountCms && input.admin !== undefined
+  const mountGraphql = mountCms && input.graphql === true
+  const mountTelemetry = input.telemetry?.enabled === true
+  const stores = input.stores ?? []
+  const registerStores = stores.length > 0
+  const hasServerStores = stores.some(s => s.scope !== 'page')
+  const hasPersistedStores = stores.some(isPersistedStore)
+
+  const databaseReasons: string[] = []
+  if (mountCms) databaseReasons.push('collections')
+  if (mountTelemetry) databaseReasons.push('telemetry')
+  if (hasPersistedStores) databaseReasons.push('persisted stores')
+
+  return {
+    mountCms,
+    mountAdmin,
+    mountGraphql,
+    mountTelemetry,
+    registerStores,
+    needsDatabase: databaseReasons.length > 0,
+    databaseReasons,
+    requiresSecret: mountCms || hasServerStores
+  }
+}

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -10,6 +10,8 @@ import { ResultAsync, fromThrowable } from '@valencets/resultkit'
 import { createPool, closePool, loadMigrations, runMigrations } from '@valencets/db'
 import type { DbConfig, DbPool } from '@valencets/db'
 import { buildCms, validateSession } from '@valencets/cms'
+import type { CmsInstance } from '@valencets/cms'
+import { planBoot } from './boot-plan.js'
 import type { RestRouteEntry } from '@valencets/cms'
 import { readLearnProgress, writeLearnProgress, createInitialProgress } from './learn/index.js'
 import { log } from './cli-utils.js'
@@ -580,25 +582,21 @@ CREATE TABLE IF NOT EXISTS "store_states" (
   console.log(initSummary(projectName, serverPort, failures, learnMode, { includeCms, adminCredentials: mintedAdmin }))
 }
 
-// -- dev --
+// -- shared boot phases (dev + start) --
 
-async function runDev (): Promise<void> {
+interface LoadedBoot {
+  readonly envDb: DbConfig | null
+  readonly loadedConfig: NonNullable<Awaited<ReturnType<typeof loadUserConfig>>>
+  readonly plan: ReturnType<typeof planBoot>
+  readonly port: number
+}
+
+/** Config first: the config alone decides what boots. Exits when absent. */
+async function loadConfigAndPlan (): Promise<LoadedBoot> {
   await registerTsxLoader()
-  const config = loadEnvConfig()
-  if (!config) {
-    console.error('  Error: missing .env or database configuration. Run from your project root.')
-    process.exit(1)
-  }
-
-  const devConfig = toDevDbConfig(config)
-
-  const port = Number(process.env.PORT ?? 3000)
-  const projectDir = process.cwd()
-
-  await ensureDevDatabase(devConfig, { createPool, closePool })
-
-  log('Running migrations...')
-  await runMigrationsForProject(projectDir, devConfig)
+  // Loads .env into process.env as a side effect; a missing database
+  // section is fine — only database-backed features demand one.
+  const envDb = loadEnvConfig()
 
   log('Loading config...')
   const loadedConfig = await loadUserConfig()
@@ -607,21 +605,51 @@ async function runDev (): Promise<void> {
     process.exit(1)
   }
 
-  const userConfig = loadedConfig.collections
-  const telemetryEnabled = loadedConfig.telemetry?.enabled ?? false
+  const plan = planBoot(loadedConfig)
+  const port = Number(process.env.PORT ?? loadedConfig.server?.port ?? 3000)
+  return { envDb, loadedConfig, plan, port }
+}
+
+/** Database only when the plan demands it — refusals name the feature. */
+async function provisionDatabase (boot: LoadedBoot, projectDir: string, mode: 'dev' | 'start'): Promise<DbPool | null> {
+  if (!boot.plan.needsDatabase) return null
+
+  const baseDb = boot.loadedConfig.db ?? boot.envDb
+  if (!baseDb) {
+    console.error(`  Error: ${boot.plan.databaseReasons.join(' + ')} need a database — add a db section to valence.config.ts or DB_* variables to .env.`)
+    process.exit(1)
+  }
+
+  if (mode === 'dev') {
+    const devConfig = toDevDbConfig(baseDb)
+    await ensureDevDatabase(devConfig, { createPool, closePool })
+    log('Running migrations...')
+    await runMigrationsForProject(projectDir, devConfig)
+    return createPool(devConfig)
+  }
+
+  log('Running migrations...')
+  const migrated = await runMigrationsForProject(projectDir, baseDb)
+  if (!migrated) {
+    console.error('  Error: migrations failed. Fix your database before starting.')
+    process.exit(1)
+  }
+  return createPool(baseDb)
+}
+
+/** CMS only when collections exist — a routes-only app never builds one. */
+async function buildCmsIfPlanned (boot: LoadedBoot, pool: DbPool | null, secret: string, projectDir: string): Promise<CmsInstance | null> {
+  if (!boot.plan.mountCms || pool === null) return null
 
   log('Building CMS...')
-  const pool = createPool(devConfig)
-
-  const devCmsSecret = process.env.CMS_SECRET ?? 'dev-secret'
   const cmsResult = buildCms({
     db: pool,
-    secret: devCmsSecret,
+    secret,
     uploadDir: join(projectDir, 'uploads'),
-    collections: userConfig,
-    telemetryPool: telemetryEnabled ? pool : undefined,
-    telemetrySiteId: loadedConfig.telemetry?.siteId,
-    requireAuth: loadedConfig.admin?.requireAuth
+    collections: boot.loadedConfig.collections,
+    telemetryPool: boot.plan.mountTelemetry ? pool : undefined,
+    telemetrySiteId: boot.loadedConfig.telemetry?.siteId,
+    requireAuth: boot.loadedConfig.admin?.requireAuth
   })
 
   if (cmsResult.isErr()) {
@@ -630,15 +658,30 @@ async function runDev (): Promise<void> {
   }
 
   const cms = cmsResult.value
-
-  // Fire plugin onInit hooks
   for (const hooks of cms.pluginHooks) {
     if (hooks.onInit) await hooks.onInit(cms)
   }
+  return cms
+}
 
-  // Learn mode setup
+// -- dev --
+
+async function runDev (): Promise<void> {
+  const boot = await loadConfigAndPlan()
+  const { loadedConfig, plan, port } = boot
+  const projectDir = process.cwd()
+  const userConfig = loadedConfig.collections
+  const devCmsSecret = process.env.CMS_SECRET ?? 'dev-secret'
+
+  const pool = await provisionDatabase(boot, projectDir, 'dev')
+  const cms = await buildCmsIfPlanned(boot, pool, devCmsSecret, projectDir)
+
+  // Learn mode setup — the tutorial walks the CMS, so it needs the database
   const learnProgress = await readLearnProgress(projectDir)
-  const learnActive = learnProgress !== null && learnProgress.enabled
+  const learnActive = learnProgress !== null && learnProgress.enabled && pool !== null
+  if (learnProgress !== null && learnProgress.enabled && pool === null) {
+    log('Learn mode needs the CMS — add collections and a database to continue the tutorial.')
+  }
 
   let learnSignals: import('./learn/types.js').LearnSignals | null = null
   let currentConfigSlugs: ReadonlyArray<string> = userConfig.map(c => c.slug)
@@ -739,7 +782,7 @@ async function runDev (): Promise<void> {
     }
 
     // Learn mode routes (before everything else)
-    if (learnActive && learnSignals && currentLearnProgress) {
+    if (learnActive && learnSignals && currentLearnProgress && pool) {
       if (pathname === '/_learn' && method === 'GET') {
         const { checkAllSteps, renderLearnPage } = await import('./learn/index.js')
         const deps = { pool, signals: learnSignals, configSlugs: currentConfigSlugs, projectDir }
@@ -782,8 +825,8 @@ async function runDev (): Promise<void> {
       return
     }
 
-    // Try admin routes first
-    const adminMatch = matchRoute(pathname, cms.adminRoutes)
+    // Try admin routes — mounted only when the plan includes the panel
+    const adminMatch = (plan.mountAdmin && cms) ? matchRoute(pathname, cms.adminRoutes) : null
     if (adminMatch) {
       if (learnActive && learnSignals) {
         const { incrementAdminViews } = await import('./learn/index.js')
@@ -796,8 +839,8 @@ async function runDev (): Promise<void> {
       }
     }
 
-    // Try REST API routes
-    const restMatch = matchRoute(pathname, cms.restRoutes)
+    // Try REST API routes — only when collections mounted the CMS
+    const restMatch = cms ? matchRoute(pathname, cms.restRoutes) : null
     if (restMatch) {
       if (learnActive && learnSignals && method === 'GET' && !req.headers['x-valence-learn']) {
         const { incrementApiGets } = await import('./learn/index.js')
@@ -888,14 +931,19 @@ async function runDev (): Promise<void> {
 
   // Register store routes (no-op if no stores defined)
   const { maybeRegisterStores } = await import('./store-wiring.js')
-  const storeHydrator = maybeRegisterStores(loadedConfig.stores, registerRoute, log, pool, devCmsSecret, clientBundleUrl)
+  const storeHydrator = maybeRegisterStores(loadedConfig.stores, registerRoute, log, pool ?? undefined, devCmsSecret, clientBundleUrl)
 
   // Mount beacon ingestion at the configured endpoint (#349)
-  maybeRegisterTelemetry(loadedConfig.telemetry, registerRoute, pool, log)
+  if (pool) {
+    maybeRegisterTelemetry(loadedConfig.telemetry, registerRoute, pool, log)
+  }
 
   // Mount the GraphQL endpoint when enabled (#350) — cms_session gated
-  await maybeRegisterGraphQL(loadedConfig.graphql, registerRoute, cms, (sessionId) =>
-    validateSession(sessionId, pool).match((userId) => userId, () => null), log)
+  if (cms && pool) {
+    const graphqlPool = pool
+    await maybeRegisterGraphQL(loadedConfig.graphql, registerRoute, cms, (sessionId) =>
+      validateSession(sessionId, graphqlPool).match((userId) => userId, () => null), log)
+  }
 
   // Schema-driven generated route map (custom routes take priority)
   const generatedRoutes = generateCollectionRoutes(userConfig, loadedConfig.routes)
@@ -904,17 +952,19 @@ async function runDev (): Promise<void> {
   // User-defined routes with loaders/actions
   const userRouteMap = buildUserRouteMap(loadedConfig.routes, projectDir, pool, cms, storeHydrator)
 
+  const adminLine = plan.mountAdmin ? `\n  Admin: http://localhost:${port}/admin` : ''
   server.listen(port, async () => {
     // Fire plugin onReady hooks
-    for (const hooks of cms.pluginHooks) {
-      if (hooks.onReady) await hooks.onReady(cms)
+    if (cms) {
+      for (const hooks of cms.pluginHooks) {
+        if (hooks.onReady) await hooks.onReady(cms)
+      }
     }
 
     console.log(`
   Valence dev server running.
 
-  Site:  http://localhost:${port}
-  Admin: http://localhost:${port}/admin${learnLine}
+  Site:  http://localhost:${port}${adminLine}${learnLine}
 
   Press Ctrl+C to stop.
 `)
@@ -924,7 +974,7 @@ async function runDev (): Promise<void> {
     log('Shutting down...')
     if (configWatcher) configWatcher.close()
     server.close()
-    await closePool(pool)
+    if (pool) await closePool(pool)
     process.exit(0)
   })
 }
@@ -954,72 +1004,32 @@ async function setupClientBundle (
 }
 
 export async function runStart (): Promise<void> {
-  await registerTsxLoader()
-  const config = loadEnvConfig()
-  if (!config) {
-    console.error('  Error: missing .env or database configuration. Run from your project root.')
-    process.exit(1)
-  }
+  const boot = await loadConfigAndPlan()
+  const { loadedConfig, plan, port } = boot
 
-  const rawPort = process.env.PORT ?? '3000'
-  const port = Number(rawPort)
   if (!Number.isFinite(port) || port < 1 || port > 65535) {
-    console.error(`  Error: invalid PORT "${rawPort}". Must be a number between 1 and 65535.`)
+    console.error(`  Error: invalid PORT "${port}". Must be a number between 1 and 65535.`)
     process.exit(1)
   }
 
-  // #339 — the secret signs anonymous store sessions; missing, default,
-  // or short values must refuse to boot rather than run forgeable.
-  const secretResult = validateProductionSecret(process.env.CMS_SECRET)
-  if (secretResult.isErr()) {
-    console.error(`  Error: ${secretResult.error.message}`)
-    process.exit(1)
+  // #339 — the secret signs cms and store sessions; missing, default, or
+  // short values must refuse to boot rather than run forgeable. Apps with
+  // no session-bearing features have nothing to sign and need no secret.
+  let cmsSecret = ''
+  if (plan.requiresSecret) {
+    const secretResult = validateProductionSecret(process.env.CMS_SECRET)
+    if (secretResult.isErr()) {
+      console.error(`  Error: ${secretResult.error.message}`)
+      process.exit(1)
+    }
+    cmsSecret = secretResult.value
   }
-  const cmsSecret = secretResult.value
 
   const projectDir = process.cwd()
-
-  log('Running migrations...')
-  const migrated = await runMigrationsForProject(projectDir, config)
-  if (!migrated) {
-    console.error('  Error: migrations failed. Fix your database before starting.')
-    process.exit(1)
-  }
-
-  log('Loading config...')
-  const loadedConfig = await loadUserConfig()
-  if (!loadedConfig) {
-    console.error('  Error: could not load valence.config.ts. Make sure it exists and exports defineConfig().')
-    process.exit(1)
-  }
-
   const userConfig = loadedConfig.collections
-  const telemetryEnabled = loadedConfig.telemetry?.enabled ?? false
 
-  log('Building CMS...')
-  const pool = createPool(config)
-
-  const cmsResult = buildCms({
-    db: pool,
-    secret: cmsSecret,
-    uploadDir: join(projectDir, 'uploads'),
-    collections: userConfig,
-    telemetryPool: telemetryEnabled ? pool : undefined,
-    telemetrySiteId: loadedConfig.telemetry?.siteId,
-    requireAuth: loadedConfig.admin?.requireAuth
-  })
-
-  if (cmsResult.isErr()) {
-    console.error('  CMS build failed:', cmsResult.error.message)
-    process.exit(1)
-  }
-
-  const cms = cmsResult.value
-
-  // Fire plugin onInit hooks
-  for (const hooks of cms.pluginHooks) {
-    if (hooks.onInit) await hooks.onInit(cms)
-  }
+  const pool = await provisionDatabase(boot, projectDir, 'start')
+  const cms = await buildCmsIfPlanned(boot, pool, cmsSecret, projectDir)
 
   // eslint-disable-next-line complexity
   const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
@@ -1074,8 +1084,8 @@ export async function runStart (): Promise<void> {
       return
     }
 
-    // Try admin routes first
-    const adminMatch = matchRoute(pathname, cms.adminRoutes)
+    // Try admin routes — mounted only when the plan includes the panel
+    const adminMatch = (plan.mountAdmin && cms) ? matchRoute(pathname, cms.adminRoutes) : null
     if (adminMatch) {
       const handler = adminMatch.entry[method]
       if (handler) {
@@ -1084,8 +1094,8 @@ export async function runStart (): Promise<void> {
       }
     }
 
-    // Try REST API routes
-    const restMatch = matchRoute(pathname, cms.restRoutes)
+    // Try REST API routes — only when collections mounted the CMS
+    const restMatch = cms ? matchRoute(pathname, cms.restRoutes) : null
     if (restMatch) {
       const handler = restMatch.entry[method]
       if (handler) {
@@ -1154,14 +1164,19 @@ export async function runStart (): Promise<void> {
 
   // Register store routes (no-op if no stores defined)
   const { maybeRegisterStores: maybeRegisterStoresProd } = await import('./store-wiring.js')
-  const storeHydrator = maybeRegisterStoresProd(loadedConfig.stores, registerRoute, undefined, pool, cmsSecret, clientBundleUrl)
+  const storeHydrator = maybeRegisterStoresProd(loadedConfig.stores, registerRoute, undefined, pool ?? undefined, cmsSecret, clientBundleUrl)
 
   // Mount beacon ingestion at the configured endpoint (#349)
-  maybeRegisterTelemetry(loadedConfig.telemetry, registerRoute, pool, log)
+  if (pool) {
+    maybeRegisterTelemetry(loadedConfig.telemetry, registerRoute, pool, log)
+  }
 
   // Mount the GraphQL endpoint when enabled (#350) — cms_session gated
-  await maybeRegisterGraphQL(loadedConfig.graphql, registerRoute, cms, (sessionId) =>
-    validateSession(sessionId, pool).match((userId) => userId, () => null), log)
+  if (cms && pool) {
+    const graphqlPool = pool
+    await maybeRegisterGraphQL(loadedConfig.graphql, registerRoute, cms, (sessionId) =>
+      validateSession(sessionId, graphqlPool).match((userId) => userId, () => null), log)
+  }
 
   // Schema-driven generated route map (custom routes take priority)
   const generatedRoutes = generateCollectionRoutes(userConfig, loadedConfig.routes)
@@ -1170,17 +1185,19 @@ export async function runStart (): Promise<void> {
   // User-defined routes with loaders/actions
   const userRouteMap = buildUserRouteMap(loadedConfig.routes, projectDir, pool, cms, storeHydrator)
 
+  const adminLine = plan.mountAdmin ? `\n  Admin: http://localhost:${port}/admin` : ''
   server.listen(port, async () => {
     // Fire plugin onReady hooks
-    for (const hooks of cms.pluginHooks) {
-      if (hooks.onReady) await hooks.onReady(cms)
+    if (cms) {
+      for (const hooks of cms.pluginHooks) {
+        if (hooks.onReady) await hooks.onReady(cms)
+      }
     }
 
     console.log(`
   Valence server running.
 
-  Site:  http://localhost:${port}
-  Admin: http://localhost:${port}/admin
+  Site:  http://localhost:${port}${adminLine}
 
   Press Ctrl+C to stop.
 `)
@@ -1189,7 +1206,7 @@ export async function runStart (): Promise<void> {
   const shutdown = async () => {
     log('Shutting down...')
     server.close(async () => {
-      await closePool(pool)
+      if (pool) await closePool(pool)
       process.exit(0)
     })
   }
@@ -1200,10 +1217,22 @@ export async function runStart (): Promise<void> {
 
 // -- migrate --
 
+/** DB-backed commands accept the database from either source: DB_* env
+ *  vars (cheap, no config load) or the config file's db section. */
+async function resolveDbForCommand (): Promise<DbConfig | null> {
+  const fromEnv = loadEnvConfig()
+  if (fromEnv) return fromEnv
+  await registerTsxLoader()
+  const loaded = await loadUserConfig()
+  return loaded?.db ?? null
+}
+
+const DB_COMMAND_HINT = '  Error: this command needs a database — add DB_* variables to .env or a db section to valence.config.ts.'
+
 async function runMigrate (): Promise<void> {
-  const config = loadEnvConfig()
+  const config = await resolveDbForCommand()
   if (!config) {
-    console.error('  Error: missing .env or database configuration. Run from your project root.')
+    console.error(DB_COMMAND_HINT)
     process.exit(1)
   }
 
@@ -1220,9 +1249,9 @@ async function runMigrate (): Promise<void> {
 // -- user:create --
 
 async function runUserCreate (): Promise<void> {
-  const config = loadEnvConfig()
+  const config = await resolveDbForCommand()
   if (!config) {
-    console.error('  Error: missing .env or database configuration.')
+    console.error(DB_COMMAND_HINT)
     process.exit(1)
   }
 
@@ -1320,9 +1349,9 @@ function detectPackageManager (): string {
 
 // -- telemetry:aggregate --
 async function runTelemetryAggregate (_args: ReadonlyArray<string>): Promise<void> {
-  const dbConfig = loadEnvConfig()
+  const dbConfig = await resolveDbForCommand()
   if (!dbConfig) {
-    console.error('  Error: missing .env or database configuration. Run from your project root.')
+    console.error(DB_COMMAND_HINT)
     process.exit(1)
   }
 

--- a/packages/valence/src/cli.ts
+++ b/packages/valence/src/cli.ts
@@ -13,7 +13,8 @@ import { buildCms, validateSession } from '@valencets/cms'
 import type { RestRouteEntry } from '@valencets/cms'
 import { readLearnProgress, writeLearnProgress, createInitialProgress } from './learn/index.js'
 import { log } from './cli-utils.js'
-import { generateConfigTemplate, generateSecret } from './config-template.js'
+import { generateConfigTemplate, generateMinimalConfigTemplate, generateSecret } from './config-template.js'
+import { generateDockerCompose, verifyDatabaseConnection, createAdminUser } from './postgres-setup.js'
 import { validateProductionSecret } from './secret-guard.js'
 import { validateColumnNaming } from './migration-checks.js'
 import { maybeRegisterTelemetry } from './telemetry-wiring.js'
@@ -125,26 +126,34 @@ async function runInit (args: ReadonlyArray<string>): Promise<void> {
   const rl = rlRaw === null ? null : createPromptQueue(rlRaw, (prompt) => { stdout.write(prompt) })
 
   const projectName = useDefaults ? (nonFlagArgs[0] ?? 'my-valence-app') : await askWithDefault(rl!, 'Project name', nonFlagArgs[0] ?? 'my-valence-app')
-  const dbName = useDefaults ? projectName.replace(/[^a-z0-9_]/g, '_') : await askWithDefault(rl!, 'Database name', projectName.replace(/[^a-z0-9_]/g, '_'))
-  const dbHost = useDefaults ? 'localhost' : await askWithDefault(rl!, 'Database host', 'localhost')
-  const dbPort = useDefaults ? '5432' : await askWithDefault(rl!, 'Database port', '5432')
-  const dbUser = useDefaults ? 'postgres' : await askWithDefault(rl!, 'Database user', 'postgres')
-  const dbPassword = useDefaults ? 'postgres' : await askWithDefault(rl!, 'Database password', 'postgres')
+
+  // Everything is opt-in: a Valence app is routes + pages by default.
+  // The CMS brings the database, collections, and REST; the admin panel
+  // rides on top of the CMS. --minimal skips all of it.
+  const includeCms = flags.minimal
+    ? false
+    : (useDefaults ? true : await confirmWithDefault(rl!, 'Include the CMS (database, collections, REST API)?', true))
+
+  const defaultDbName = projectName.replace(/[^a-z0-9_]/g, '_')
+  const dbName = includeCms ? (useDefaults ? defaultDbName : await askWithDefault(rl!, 'Database name', defaultDbName)) : defaultDbName
+  const dbHost = includeCms && !useDefaults ? await askWithDefault(rl!, 'Database host', 'localhost') : 'localhost'
+  const dbPort = includeCms && !useDefaults ? await askWithDefault(rl!, 'Database port', '5432') : '5432'
+  const dbUser = includeCms && !useDefaults ? await askWithDefault(rl!, 'Database user', 'postgres') : 'postgres'
+  const dbPassword = includeCms && !useDefaults ? await askWithDefault(rl!, 'Database password', 'postgres') : 'postgres'
+
+  const includeAdmin = includeCms && (useDefaults ? true : await confirmWithDefault(rl!, 'Include the admin panel?', true))
+  const adminEmail = includeAdmin && !useDefaults ? await askWithDefault(rl!, 'Admin email', 'admin@localhost') : 'admin@localhost'
+  const generatedAdminPassword = generateSecret().slice(0, 16)
+  const adminPassword = includeAdmin && !useDefaults
+    ? await askWithDefault(rl!, 'Admin password', generatedAdminPassword)
+    : generatedAdminPassword
+
   const serverPort = useDefaults ? '3000' : await askWithDefault(rl!, 'Server port', '3000')
 
-  if (!useDefaults) {
-    console.log()
-    log('Frontend framework:')
-    log('  1. None (plain HTML templates)')
-    log('  2. Astro (recommended for static + islands)')
-    log('  3. Bring your own')
-  }
-  const frameworkChoice = useDefaults ? '1' : await askWithDefault(rl!, 'Choose', '1')
-
   const installDeps = !flags.noInstall && (useDefaults ? true : await confirmWithDefault(rl!, 'Install dependencies?', true))
-  const createDb = !flags.noDb && (useDefaults ? true : await confirmWithDefault(rl!, `Create database "${dbName}"?`, true))
-  const doMigrate = !flags.noMigrate && (useDefaults ? true : await confirmWithDefault(rl!, 'Run initial migrations?', true))
-  const doSeed = !flags.noSeed && (useDefaults ? true : await confirmWithDefault(rl!, 'Insert sample seed data?', true))
+  const createDb = includeCms && !flags.noDb && (useDefaults ? true : await confirmWithDefault(rl!, `Create database "${dbName}"?`, true))
+  const doMigrate = includeCms && !flags.noMigrate && (useDefaults ? true : await confirmWithDefault(rl!, 'Run initial migrations?', true))
+  const doSeed = includeCms && !flags.noSeed && (useDefaults ? true : await confirmWithDefault(rl!, 'Insert sample seed data?', true))
   const initGit = !flags.noGit && (useDefaults ? true : await confirmWithDefault(rl!, 'Initialize git repository?', true))
 
   if (rlRaw) rlRaw.close()
@@ -157,16 +166,11 @@ async function runInit (args: ReadonlyArray<string>): Promise<void> {
   log(`Creating ${projectName}...`)
 
   await mkdir(dir, { recursive: true })
-  await mkdir(join(dir, 'collections'), { recursive: true })
-  await mkdir(join(dir, 'migrations'), { recursive: true })
   await mkdir(join(dir, 'public'), { recursive: true })
-  await mkdir(join(dir, 'uploads'), { recursive: true })
-
-  const extraDeps: Record<string, string> = {}
-  const frameworkMap: Record<string, string> = { 2: 'astro' }
-  const framework = frameworkMap[frameworkChoice]
-  if (framework === 'astro') {
-    extraDeps.astro = '^5.0.0'
+  if (includeCms) {
+    await mkdir(join(dir, 'collections'), { recursive: true })
+    await mkdir(join(dir, 'migrations'), { recursive: true })
+    await mkdir(join(dir, 'uploads'), { recursive: true })
   }
 
   const cliDir = dirname(fileURLToPath(import.meta.url))
@@ -183,16 +187,18 @@ async function runInit (args: ReadonlyArray<string>): Promise<void> {
       'user:create': 'valence user:create',
       start: 'node dist/server.js'
     },
-    dependencies: {
-      ...scaffoldDependencies(cliPkg.version, cliPkg.dependencies ?? {}),
-      ...extraDeps
-    },
+    dependencies: scaffoldDependencies(cliPkg.version, cliPkg.dependencies ?? {}),
     devDependencies: {
       typescript: '^5.9.3'
     }
   }, null, 2) + '\n')
 
-  await writeFile(join(dir, 'valence.config.ts'), generateConfigTemplate({ dbName, dbUser, dbPassword, serverPort, learnMode }))
+  await writeFile(
+    join(dir, 'valence.config.ts'),
+    includeCms
+      ? generateConfigTemplate({ dbName, dbUser, dbPassword, serverPort, learnMode, includeAdmin })
+      : generateMinimalConfigTemplate(serverPort)
+  )
 
   await writeFile(join(dir, 'tsconfig.json'), JSON.stringify({
     compilerOptions: {
@@ -213,29 +219,20 @@ async function runInit (args: ReadonlyArray<string>): Promise<void> {
     include: ['*.ts', 'collections/**/*.ts']
   }, null, 2) + '\n')
 
-  const envContent = `DB_HOST=${dbHost}
-DB_PORT=${dbPort}
-DB_NAME=${dbName}
-DB_USER=${dbUser}
-DB_PASSWORD=${dbPassword}
-PORT=${serverPort}
-CMS_SECRET=${generateSecret()}
-`
-  await writeFile(join(dir, '.env'), envContent)
-  const envExampleContent = `DB_HOST=${dbHost}
-DB_PORT=${dbPort}
-DB_NAME=${dbName}
-DB_USER=${dbUser}
-DB_PASSWORD=
-PORT=${serverPort}
-CMS_SECRET=change-me
-`
-  await writeFile(join(dir, '.env.example'), envExampleContent)
+  const dbEnvLines = includeCms
+    ? `DB_HOST=${dbHost}\nDB_PORT=${dbPort}\nDB_NAME=${dbName}\nDB_USER=${dbUser}\nDB_PASSWORD=${dbPassword}\n`
+    : ''
+  const dbEnvExampleLines = includeCms
+    ? `DB_HOST=${dbHost}\nDB_PORT=${dbPort}\nDB_NAME=${dbName}\nDB_USER=${dbUser}\nDB_PASSWORD=\n`
+    : ''
+  await writeFile(join(dir, '.env'), `${dbEnvLines}PORT=${serverPort}\nCMS_SECRET=${generateSecret()}\n`)
+  await writeFile(join(dir, '.env.example'), `${dbEnvExampleLines}PORT=${serverPort}\nCMS_SECRET=change-me\n`)
 
   const gitignoreLines = ['node_modules/', 'dist/', '.env', 'uploads/', '*.log']
   if (learnMode) gitignoreLines.push('.valence/')
   await writeFile(join(dir, '.gitignore'), gitignoreLines.join('\n') + '\n')
 
+  const adminReadmeLine = includeCms ? `\nAdmin: http://localhost:${serverPort}/admin` : ''
   await writeFile(join(dir, 'README.md'), `# ${projectName}
 
 Built with [Valence](https://valence.build).
@@ -246,11 +243,17 @@ Built with [Valence](https://valence.build).
 pnpm dev
 \`\`\`
 
-Site: http://localhost:${serverPort}
-Admin: http://localhost:${serverPort}/admin
+Site: http://localhost:${serverPort}${adminReadmeLine}
 `)
 
-  await writeFile(join(dir, 'migrations', '001-init.sql'), `CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+  if (includeCms) {
+    // postgres 16 wired to the answers — `docker compose up -d` stands the
+    // database up when none is installed locally.
+    await writeFile(join(dir, 'docker-compose.yml'), generateDockerCompose(dbAnswers))
+  }
+
+  if (includeCms) {
+    await writeFile(join(dir, 'migrations', '001-init.sql'), `CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 -- Valence column naming rules:
 -- System columns use snake_case:  id, created_at, updated_at, deleted_at
@@ -396,32 +399,56 @@ CREATE TABLE IF NOT EXISTS "store_states" (
   PRIMARY KEY ("store_slug", "state_key")
 );
 `)
+  }
 
-  // Scaffold FSD src/ directory from the collections we just wrote
-  const { collection: col, field: f } = await import('@valencets/cms')
-  const initCollections = [
-    col({
-      slug: 'posts',
-      labels: { singular: 'Post', plural: 'Posts' },
-      fields: [
-        f.text({ name: 'title', required: true }),
-        f.slug({ name: 'slug', required: true, unique: true, slugFrom: 'title' }),
-        f.richtext({ name: 'body' }),
-        f.boolean({ name: 'published' }),
-        f.date({ name: 'publishedAt' })
-      ]
-    }),
-    col({
-      slug: 'users',
-      auth: true,
-      fields: [
-        f.text({ name: 'name', required: true }),
-        f.select({ name: 'role', defaultValue: 'editor', options: [{ label: 'Admin', value: 'admin' }, { label: 'Editor', value: 'editor' }] })
-      ]
-    })
-  ]
-  await scaffoldFsd({ projectDir: dir, collections: initCollections })
-  log('FSD source directory scaffolded.')
+  if (includeCms) {
+    // Scaffold FSD src/ directory from the collections we just wrote
+    const { collection: col, field: f } = await import('@valencets/cms')
+    const initCollections = [
+      col({
+        slug: 'posts',
+        labels: { singular: 'Post', plural: 'Posts' },
+        fields: [
+          f.text({ name: 'title', required: true }),
+          f.slug({ name: 'slug', required: true, unique: true, slugFrom: 'title' }),
+          f.richtext({ name: 'body' }),
+          f.boolean({ name: 'published' }),
+          f.date({ name: 'publishedAt' })
+        ]
+      }),
+      col({
+        slug: 'users',
+        auth: true,
+        fields: [
+          f.text({ name: 'name', required: true }),
+          f.select({ name: 'role', defaultValue: 'editor', options: [{ label: 'Admin', value: 'admin' }, { label: 'Editor', value: 'editor' }] })
+        ]
+      })
+    ]
+    await scaffoldFsd({ projectDir: dir, collections: initCollections })
+    log('FSD source directory scaffolded.')
+  } else {
+    // A starter page — routes + pages are the whole app until the config
+    // opts into more.
+    await mkdir(join(dir, 'src', 'pages', 'home', 'ui'), { recursive: true })
+    await writeFile(join(dir, 'src', 'pages', 'home', 'ui', 'index.html'), `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${projectName}</title>
+</head>
+<body>
+  <main>
+    <h1>${projectName}</h1>
+    <p>This page lives at <code>src/pages/home/ui/index.html</code>.</p>
+    <p>Try the example route: <a href="/api/hello/world">/api/hello/world</a></p>
+  </main>
+</body>
+</html>
+`)
+    log('Starter page scaffolded.')
+  }
 
   log('Project scaffolded.')
 
@@ -457,8 +484,30 @@ CREATE TABLE IF NOT EXISTS "store_states" (
     }
   }
 
-  if (doMigrate) {
-    let baseMigrated = false
+  // Success is earned: verify the database actually answers before
+  // migrating, and point at the scaffolded compose file when it does not.
+  let databaseReachable = false
+  if (includeCms && (createDb || doMigrate)) {
+    const verification = await verifyDatabaseConnection({
+      host: dbHost,
+      port: Number(dbPort),
+      database: dbName,
+      username: dbUser,
+      password: dbPassword,
+      max: 1,
+      idle_timeout: 5,
+      connect_timeout: 5
+    })
+    databaseReachable = verification.isOk()
+    if (verification.isErr()) {
+      log(`Warning: postgres is not reachable at ${dbHost}:${dbPort} (${verification.error.message}).`)
+      log('  Stand one up with: docker compose up -d   (docker-compose.yml is scaffolded)')
+      failures.push(`postgres unreachable at ${dbHost}:${dbPort} — run \`docker compose up -d\` in ${projectName}/, then \`valence migrate\` and \`valence user:create\``)
+    }
+  }
+
+  let baseMigrated = false
+  if (doMigrate && databaseReachable) {
     for (const target of migrationTargets(dbAnswers)) {
       log(`Running migrations on "${target.database}"...`)
       const migrated = await runMigrationsForProject(dir, target)
@@ -470,30 +519,54 @@ CREATE TABLE IF NOT EXISTS "store_states" (
         failures.push(`migrations failed on ${target.database} — run \`valence migrate\` after fixing the connection`)
       }
     }
-    if (baseMigrated) {
-      if (doSeed) {
-        log('Seeding initial data...')
-        const seedPool = createPool({
-          host: dbHost,
-          port: Number(dbPort),
-          database: dbName,
-          username: dbUser,
-          password: dbPassword,
-          max: 5,
-          idle_timeout: 10,
-          connect_timeout: 10
-        })
-        const seedResult = await ResultAsync.fromPromise(
-          (async () => { await seedDatabase(seedPool); await closePool(seedPool) })(),
-          () => null
-        )
-        if (seedResult.isOk()) {
-          log('Seed data inserted.')
-        } else {
-          log('Warning: seed data insertion failed. The database may already have data.')
-        }
+    if (baseMigrated && doSeed) {
+      log('Seeding initial data...')
+      const seedPool = createPool({
+        host: dbHost,
+        port: Number(dbPort),
+        database: dbName,
+        username: dbUser,
+        password: dbPassword,
+        max: 5,
+        idle_timeout: 10,
+        connect_timeout: 10
+      })
+      const seedResult = await ResultAsync.fromPromise(
+        (async () => { await seedDatabase(seedPool); await closePool(seedPool) })(),
+        () => null
+      )
+      if (seedResult.isOk()) {
+        log('Seed data inserted.')
+      } else {
+        log('Warning: seed data insertion failed. The database may already have data.')
       }
     }
+  }
+
+  // Mint the admin during init so the panel is usable on first boot.
+  let mintedAdmin: { email: string, password: string } | undefined
+  if (includeAdmin && baseMigrated) {
+    const adminPool = createPool({
+      host: dbHost,
+      port: Number(dbPort),
+      database: dbName,
+      username: dbUser,
+      password: dbPassword,
+      max: 1,
+      idle_timeout: 5,
+      connect_timeout: 5
+    })
+    const created = await createAdminUser(adminPool, { email: adminEmail, password: adminPassword, name: 'Admin' })
+    await closePool(adminPool)
+    if (created.isOk()) {
+      log(`Admin user "${adminEmail}" created.`)
+      mintedAdmin = { email: adminEmail, password: adminPassword }
+    } else {
+      log(`Warning: admin user creation failed: ${created.error.message}`)
+      failures.push('admin user creation failed — run `valence user:create` once the database is reachable')
+    }
+  } else if (includeAdmin && includeCms) {
+    failures.push('admin user not created — run `valence user:create` once the database is migrated')
   }
 
   if (initGit) {
@@ -504,7 +577,7 @@ CREATE TABLE IF NOT EXISTS "store_states" (
     }
   }
 
-  console.log(initSummary(projectName, serverPort, failures, learnMode))
+  console.log(initSummary(projectName, serverPort, failures, learnMode, { includeCms, adminCredentials: mintedAdmin }))
 }
 
 // -- dev --

--- a/packages/valence/src/config-loader.ts
+++ b/packages/valence/src/config-loader.ts
@@ -24,6 +24,13 @@ export async function registerTsxLoader (): Promise<void> {
 
 export interface UserConfig {
   readonly collections: ReadonlyArray<CollectionConfig>
+  // Resolved db section from valence.config.ts — the CLI prefers it over
+  // DB_* env vars; both are optional for database-less apps.
+  readonly db?: DbConfig | undefined
+  readonly server?: {
+    readonly port: number
+    readonly host: string
+  } | undefined
   readonly admin?: {
     readonly requireAuth?: boolean | undefined
   } | undefined
@@ -122,6 +129,8 @@ export async function loadUserConfig (): Promise<UserConfig | null> {
     if (result && typeof result.isOk === 'function' && result.isOk()) {
       return {
         collections: result.value?.collections ?? [],
+        db: result.value?.db,
+        server: result.value?.server,
         admin: result.value?.admin,
         telemetry: result.value?.telemetry,
         // onServer, routes, and stores contain functions and can only be
@@ -152,6 +161,8 @@ async function loadViaSubprocess (configPath: string): Promise<UserConfig | null
     '        slug: c.slug, labels: c.labels, auth: c.auth, upload: c.upload,',
     '        timestamps: c.timestamps, fields: c.fields',
     '      })),',
+    '      db: r.value.db,',
+    '      server: r.value.server,',
     '      admin: r.value.admin,',
     '      telemetry: r.value.telemetry,',
     '      graphql: r.value.graphql',
@@ -182,11 +193,11 @@ async function loadViaSubprocess (configPath: string): Promise<UserConfig | null
 
   const parseResult = safeJsonParseConfig(output)
   if (parseResult.isErr() || parseResult.value === null) return null
-  const parsed = parseResult.value as { collections: import('@valencets/cms').CollectionConfig[]; admin?: UserConfig['admin']; telemetry?: UserConfig['telemetry']; graphql?: boolean }
+  const parsed = parseResult.value as { collections: import('@valencets/cms').CollectionConfig[]; db?: DbConfig; server?: UserConfig['server']; admin?: UserConfig['admin']; telemetry?: UserConfig['telemetry']; graphql?: boolean }
 
   // Re-hydrate through collection() to get proper CollectionConfig objects.
   // onServer and routes cannot be recovered from the subprocess — functions are not serialisable.
   const { collection: col } = await import('@valencets/cms')
   const collections = parsed.collections.map((c) => col(c))
-  return { collections, admin: parsed.admin, telemetry: parsed.telemetry, graphql: parsed.graphql }
+  return { collections, db: parsed.db, server: parsed.server, admin: parsed.admin, telemetry: parsed.telemetry, graphql: parsed.graphql }
 }

--- a/packages/valence/src/config-template.ts
+++ b/packages/valence/src/config-template.ts
@@ -6,10 +6,13 @@ export interface ConfigTemplateOptions {
   readonly dbPassword: string
   readonly serverPort: string
   readonly learnMode: boolean
+  /** Omit the admin section for headless CMS projects. Defaults true. */
+  readonly includeAdmin?: boolean
 }
 
 export function generateConfigTemplate (opts: ConfigTemplateOptions): string {
   const { dbName, dbUser, dbPassword, serverPort, learnMode } = opts
+  const includeAdmin = opts.includeAdmin ?? true
 
   const learnComment = (text: string) => learnMode ? `// ${text}\n    ` : ''
   const dbSslModeExpression = `process.env.DB_SSLMODE === 'disable' ||
@@ -80,15 +83,46 @@ export default defineConfig({
       ]
     })${tagsCollection}
   ],
-  admin: {
+${includeAdmin
+    ? `  admin: {
     pathPrefix: '/admin',
     requireAuth: true
   },
-  telemetry: {
+`
+    : ''}  telemetry: {
     enabled: true,
     endpoint: '/api/telemetry',
     siteId: process.env.SITE_ID ?? '${dbName}'
   }
+})
+`
+}
+
+/**
+ * The CMS-less scaffold: a Valence app is routes + pages by default.
+ * No database, no collections, no admin — add them later by extending
+ * this config; every capability is derived from what the config declares.
+ */
+export function generateMinimalConfigTemplate (serverPort: string): string {
+  return `import { defineConfig } from '@valencets/valence'
+
+// A Valence app is routes + pages by default. Everything else is opt-in:
+// add \`collections\` (with a \`db\` section or DB_* env vars) for the CMS,
+// \`admin\` for the panel, \`stores\` for live shared state, \`telemetry\`
+// for first-party analytics — the server derives what to mount from what
+// this file declares.
+export default defineConfig({
+  server: {
+    port: Number(process.env.PORT ?? ${serverPort})
+  },
+  routes: [
+    {
+      path: '/api/hello/:name',
+      loader: async ({ params }) => ({
+        data: { greeting: \`Hello, \${params.name}!\` }
+      })
+    }
+  ]
 })
 `
 }

--- a/packages/valence/src/define-config.ts
+++ b/packages/valence/src/define-config.ts
@@ -71,7 +71,9 @@ export interface OnServerContext {
 }
 
 export interface ValenceConfig {
-  readonly db: {
+  // Optional — only database-backed features (collections, telemetry,
+  // persisted stores) need it, and it may come from .env at boot instead.
+  readonly db?: {
     readonly host: string
     readonly port: number
     readonly database: string
@@ -83,12 +85,15 @@ export interface ValenceConfig {
     readonly query_timeout?: number | undefined
     readonly sslmode?: 'disable' | 'require' | 'verify-ca' | 'verify-full' | undefined
     readonly sslrootcert?: string | undefined
-  }
-  readonly server: {
-    readonly port: number
+  } | undefined
+  // Optional — defaults to port 3000 on 0.0.0.0.
+  readonly server?: {
+    readonly port?: number | undefined
     readonly host?: string | undefined
-  }
-  readonly collections: ReadonlyArray<CollectionConfig>
+  } | undefined
+  // Optional — a Valence app is routes + pages by default; collections
+  // opt in to the CMS (database, REST, Local API).
+  readonly collections?: ReadonlyArray<CollectionConfig> | undefined
   readonly telemetry?: {
     readonly enabled: boolean
     readonly endpoint: string
@@ -121,7 +126,7 @@ export interface ValenceConfig {
 }
 
 export interface ResolvedValenceConfig {
-  readonly db: {
+  readonly db?: {
     readonly host: string
     readonly port: number
     readonly database: string
@@ -133,7 +138,7 @@ export interface ResolvedValenceConfig {
     readonly query_timeout?: number | undefined
     readonly sslmode: 'disable' | 'require' | 'verify-ca' | 'verify-full'
     readonly sslrootcert?: string | undefined
-  }
+  } | undefined
   readonly server: {
     readonly port: number
     readonly host: string
@@ -198,12 +203,12 @@ const dbSchema = z.object({
 })
 
 const configSchema = z.object({
-  db: dbSchema,
+  db: dbSchema.optional(),
   server: z.object({
-    port: z.number().int().min(1).max(65535),
+    port: z.number().int().min(1).max(65535).optional(),
     host: z.string().min(1).optional()
-  }),
-  collections: z.array(collectionSchema),
+  }).optional(),
+  collections: z.array(collectionSchema).optional(),
   telemetry: z.object({
     enabled: z.boolean(),
     endpoint: z.string().min(1),
@@ -221,6 +226,25 @@ const configSchema = z.object({
   }).optional()
 })
 
+type ParsedDbSection = NonNullable<z.infer<typeof configSchema>['db']>
+
+function resolveDbSection (db: ParsedDbSection | undefined): ResolvedValenceConfig['db'] {
+  if (!db) return undefined
+  return {
+    host: db.host,
+    port: db.port,
+    database: db.database,
+    username: db.username,
+    password: db.password,
+    max: db.max ?? 10,
+    idle_timeout: db.idle_timeout ?? 30,
+    connect_timeout: db.connect_timeout ?? 10,
+    query_timeout: db.query_timeout,
+    sslmode: db.sslmode ?? 'disable',
+    sslrootcert: db.sslrootcert
+  }
+}
+
 export function defineConfig (config: ValenceConfig): Result<ResolvedValenceConfig, ConfigError> {
   // Strip onServer, routes, and stores before Zod validation — all contain function
   // values that Zod cannot validate. Preserve them and re-attach after resolution.
@@ -237,7 +261,7 @@ export function defineConfig (config: ValenceConfig): Result<ResolvedValenceConf
     })
   }
 
-  const collectionValidation = validateCollections(config.collections)
+  const collectionValidation = validateCollections(config.collections ?? [])
   if (collectionValidation.isErr()) {
     const errors = collectionValidation.error
     const firstError = errors[0]
@@ -255,24 +279,12 @@ export function defineConfig (config: ValenceConfig): Result<ResolvedValenceConf
   const data = parsed.data
 
   const resolved: ResolvedValenceConfig = {
-    db: {
-      host: data.db.host,
-      port: data.db.port,
-      database: data.db.database,
-      username: data.db.username,
-      password: data.db.password,
-      max: data.db.max ?? 10,
-      idle_timeout: data.db.idle_timeout ?? 30,
-      connect_timeout: data.db.connect_timeout ?? 10,
-      query_timeout: data.db.query_timeout,
-      sslmode: data.db.sslmode ?? 'disable',
-      sslrootcert: data.db.sslrootcert
-    },
+    db: resolveDbSection(data.db),
     server: {
-      port: data.server.port,
-      host: data.server.host ?? '0.0.0.0'
+      port: data.server?.port ?? 3000,
+      host: data.server?.host ?? '0.0.0.0'
     },
-    collections: config.collections,
+    collections: config.collections ?? [],
     telemetry: data.telemetry
       ? {
           enabled: data.telemetry.enabled,

--- a/packages/valence/src/define-config.ts
+++ b/packages/valence/src/define-config.ts
@@ -14,8 +14,10 @@ export interface LoaderContext {
   readonly params: Record<string, string>
   readonly query: URLSearchParams
   readonly req: IncomingMessage
-  readonly pool: DbPool
-  readonly cms: CmsInstance
+  /** null when the app runs without a database (optional-everything boot). */
+  readonly pool: DbPool | null
+  /** null when the app runs without collections. */
+  readonly cms: CmsInstance | null
 }
 
 // Result returned by a loader function
@@ -31,8 +33,10 @@ export interface ActionContext {
   readonly params: Record<string, string>
   readonly body: URLSearchParams
   readonly req: IncomingMessage
-  readonly pool: DbPool
-  readonly cms: CmsInstance
+  /** null when the app runs without a database (optional-everything boot). */
+  readonly pool: DbPool | null
+  /** null when the app runs without collections. */
+  readonly cms: CmsInstance | null
 }
 
 // Result returned by an action function
@@ -65,8 +69,10 @@ export interface RouteConfig {
 // register custom routes, etc., without abandoning `valence dev`.
 export interface OnServerContext {
   readonly server: Server
-  readonly pool: DbPool
-  readonly cms: CmsInstance
+  /** null when the app runs without a database (optional-everything boot). */
+  readonly pool: DbPool | null
+  /** null when the app runs without collections. */
+  readonly cms: CmsInstance | null
   readonly registerRoute: (method: string, path: string, handler: RouteHandler) => void
 }
 

--- a/packages/valence/src/init-steps.ts
+++ b/packages/valence/src/init-steps.ts
@@ -10,6 +10,8 @@ export interface InitFlags {
   readonly noMigrate: boolean
   readonly noSeed: boolean
   readonly noGit: boolean
+  /** CMS-less scaffold: routes + pages only, no database, no admin. */
+  readonly minimal: boolean
 }
 
 export function parseInitFlags (args: ReadonlyArray<string>): InitFlags {
@@ -20,7 +22,8 @@ export function parseInitFlags (args: ReadonlyArray<string>): InitFlags {
     noDb: args.includes('--no-db'),
     noMigrate: args.includes('--no-migrate'),
     noSeed: args.includes('--no-seed'),
-    noGit: args.includes('--no-git')
+    noGit: args.includes('--no-git'),
+    minimal: args.includes('--minimal')
   }
 }
 
@@ -116,10 +119,29 @@ export function migrationTargets (answers: DbConnectionAnswers): readonly Migrat
   ]
 }
 
+export interface InitSummaryOptions {
+  /** false → CMS-less project: no admin URL to advertise. Defaults true. */
+  readonly includeCms?: boolean
+  /** Credentials init minted — printed exactly once, here. */
+  readonly adminCredentials?: { readonly email: string, readonly password: string } | undefined
+}
+
 /** The closing message earns its optimism: any failed step turns it into
  *  an honest checklist instead of "your project is ready". */
-export function initSummary (projectName: string, serverPort: number | string, failures: readonly string[], learnMode: boolean): string {
+export function initSummary (
+  projectName: string,
+  serverPort: number | string,
+  failures: readonly string[],
+  learnMode: boolean,
+  options?: InitSummaryOptions
+): string {
+  const includeCms = options?.includeCms ?? true
   const learnUrl = learnMode ? `\n  Tutorial: http://localhost:${serverPort}/_learn` : ''
+  const adminUrl = includeCms ? `\n  Admin: http://localhost:${serverPort}/admin` : ''
+  const credentials = options?.adminCredentials !== undefined
+    ? `\n  Admin login — shown once, change it after first sign-in:\n    email:    ${options.adminCredentials.email}\n    password: ${options.adminCredentials.password}\n`
+    : ''
+
   if (failures.length === 0) {
     return `
   Done. Your project is ready.
@@ -127,9 +149,8 @@ export function initSummary (projectName: string, serverPort: number | string, f
     cd ${projectName}
     pnpm dev
 
-  Site:  http://localhost:${serverPort}
-  Admin: http://localhost:${serverPort}/admin${learnUrl}
-`
+  Site:  http://localhost:${serverPort}${adminUrl}${learnUrl}
+${credentials}`
   }
   const list = failures.map(f => `    - ${f}`).join('\n')
   return `
@@ -142,9 +163,8 @@ ${list}
     cd ${projectName}
     pnpm dev
 
-  Site:  http://localhost:${serverPort}
-  Admin: http://localhost:${serverPort}/admin${learnUrl}
-`
+  Site:  http://localhost:${serverPort}${adminUrl}${learnUrl}
+${credentials}`
 }
 
 interface LineSource {

--- a/packages/valence/src/postgres-setup.ts
+++ b/packages/valence/src/postgres-setup.ts
@@ -1,0 +1,105 @@
+import { ResultAsync } from '@valencets/resultkit'
+import type { DbConfig, DbPool } from '@valencets/db'
+import { createPool as realCreatePool, closePool as realClosePool } from '@valencets/db'
+import { hashPassword } from '@valencets/cms'
+import type { DbConnectionAnswers } from './init-steps.js'
+
+/**
+ * CMS init must set postgres up properly, not just hope: a compose file so
+ * the database can be stood up when absent, connectivity verified before
+ * claiming success, and the admin user minted during init when the panel
+ * is chosen.
+ */
+
+export interface SetupError {
+  readonly code: 'CONNECTION_FAILED' | 'ADMIN_CREATE_FAILED'
+  readonly message: string
+}
+
+/** postgres 16 wired to the exact answers init collected — `docker compose up -d` and go. */
+export function generateDockerCompose (answers: DbConnectionAnswers): string {
+  return `services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${answers.dbName}
+      POSTGRES_USER: ${answers.dbUser}
+      POSTGRES_PASSWORD: ${answers.dbPassword}
+    ports:
+      - "${answers.dbPort}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${answers.dbUser}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  pgdata:
+`
+}
+
+interface VerifyDeps {
+  readonly createPool: typeof realCreatePool
+  readonly closePool: typeof realClosePool
+}
+
+const DEFAULT_DEPS: VerifyDeps = { createPool: realCreatePool, closePool: realClosePool }
+
+/** SELECT 1 round-trip — success is earned, never assumed. */
+export function verifyDatabaseConnection (
+  config: DbConfig,
+  deps: VerifyDeps = DEFAULT_DEPS
+): ResultAsync<void, SetupError> {
+  const pool = deps.createPool(config)
+  return ResultAsync.fromPromise(
+    pool.sql`SELECT 1 AS one`,
+    (e): SetupError => ({
+      code: 'CONNECTION_FAILED',
+      message: e instanceof Error ? e.message : 'Could not reach the database'
+    })
+  )
+    .map(() => undefined)
+    .andThen((value) =>
+      ResultAsync.fromPromise(
+        Promise.resolve(deps.closePool(pool)).then(() => value, () => value),
+        (): SetupError => ({ code: 'CONNECTION_FAILED', message: 'Failed to close verification pool' })
+      )
+    )
+    .orElse((error) =>
+      ResultAsync.fromPromise(
+        Promise.resolve(deps.closePool(pool)).then(() => undefined, () => undefined),
+        (): SetupError => error
+      ).andThen(() => ResultAsync.fromPromise(Promise.reject(new Error(error.message)), (): SetupError => error))
+    )
+}
+
+export interface AdminUserAnswers {
+  readonly email: string
+  readonly password: string
+  readonly name: string
+}
+
+/**
+ * Mint the admin during init so the panel is usable on first boot. The
+ * password rides as an argon2id hash — plaintext never reaches SQL.
+ * Parameterized insert; ON CONFLICT keeps re-runs idempotent.
+ */
+export function createAdminUser (pool: DbPool, answers: AdminUserAnswers): ResultAsync<void, SetupError> {
+  return hashPassword(answers.password)
+    .mapErr((e): SetupError => ({ code: 'ADMIN_CREATE_FAILED', message: e.message }))
+    .andThen((hash) =>
+      ResultAsync.fromPromise(
+        pool.sql.unsafe(
+          'INSERT INTO "users" ("id", "email", "password_hash", "name", "role") VALUES (gen_random_uuid(), $1, $2, $3, $4) ON CONFLICT ("email") DO NOTHING RETURNING "id"',
+          [answers.email, hash, answers.name, 'admin']
+        ),
+        (e): SetupError => ({
+          code: 'ADMIN_CREATE_FAILED',
+          message: e instanceof Error ? e.message : 'Admin user insert failed'
+        })
+      ).map(() => undefined)
+    )
+}

--- a/packages/valence/src/route-generator.ts
+++ b/packages/valence/src/route-generator.ts
@@ -145,8 +145,8 @@ function mergeResponseHeaders (
 function makeLoaderHandler (
   route: RouteConfig,
   projectDir: string,
-  pool: DbPool,
-  cms: CmsInstance,
+  pool: DbPool | null,
+  cms: CmsInstance | null,
   storeHydrator?: StoreHydrator
 ): RouteHandler {
   const loader = route.loader!
@@ -193,8 +193,8 @@ function makeLoaderHandler (
 function makeActionHandler (
   route: RouteConfig,
   projectDir: string,
-  pool: DbPool,
-  cms: CmsInstance
+  pool: DbPool | null,
+  cms: CmsInstance | null
 ): RouteHandler {
   const action = route.action!
   const templatePath = resolveTemplatePath(route.path, projectDir)
@@ -238,8 +238,8 @@ function makeActionHandler (
 export function buildUserRouteMap (
   routes: readonly RouteConfig[] | undefined,
   projectDir: string,
-  pool: DbPool,
-  cms: CmsInstance,
+  pool: DbPool | null,
+  cms: CmsInstance | null,
   storeHydrator?: StoreHydrator
 ): Map<string, Map<string, RouteHandler>> {
   const routeMap = new Map<string, Map<string, RouteHandler>>()

--- a/packages/valence/valence.api.md
+++ b/packages/valence/valence.api.md
@@ -23,12 +23,10 @@ import type { StoreState } from '@valencets/store';
 export interface ActionContext {
     // (undocumented)
     readonly body: URLSearchParams;
-    // (undocumented)
-    readonly cms: CmsInstance;
+    readonly cms: CmsInstance | null;
     // (undocumented)
     readonly params: Record<string, string>;
-    // (undocumented)
-    readonly pool: DbPool;
+    readonly pool: DbPool | null;
     // (undocumented)
     readonly req: IncomingMessage;
 }
@@ -57,7 +55,7 @@ export interface ActionResult {
 export function buildGeneratedRouteMap(routes: readonly GeneratedRoute[], projectDir: string, storeHydrator?: StoreHydrator): Map<string, Map<string, RouteHandler>>;
 
 // @public (undocumented)
-export function buildUserRouteMap(routes: readonly RouteConfig[] | undefined, projectDir: string, pool: DbPool, cms: CmsInstance, storeHydrator?: StoreHydrator): Map<string, Map<string, RouteHandler>>;
+export function buildUserRouteMap(routes: readonly RouteConfig[] | undefined, projectDir: string, pool: DbPool | null, cms: CmsInstance | null, storeHydrator?: StoreHydrator): Map<string, Map<string, RouteHandler>>;
 
 export { collection }
 
@@ -125,12 +123,10 @@ export type JsonValue = JsonPrimitive | JsonArray | JsonObject;
 
 // @public (undocumented)
 export interface LoaderContext {
-    // (undocumented)
-    readonly cms: CmsInstance;
+    readonly cms: CmsInstance | null;
     // (undocumented)
     readonly params: Record<string, string>;
-    // (undocumented)
-    readonly pool: DbPool;
+    readonly pool: DbPool | null;
     // (undocumented)
     readonly query: URLSearchParams;
     // (undocumented)
@@ -159,10 +155,8 @@ export interface LoaderResult {
 
 // @public (undocumented)
 export interface OnServerContext {
-    // (undocumented)
-    readonly cms: CmsInstance;
-    // (undocumented)
-    readonly pool: DbPool;
+    readonly cms: CmsInstance | null;
+    readonly pool: DbPool | null;
     // (undocumented)
     readonly registerRoute: (method: string, path: string, handler: RouteHandler) => void;
     // (undocumented)
@@ -182,7 +176,7 @@ export interface ResolvedValenceConfig {
     // (undocumented)
     readonly collections: ReadonlyArray<CollectionConfig>;
     // (undocumented)
-    readonly db: {
+    readonly db?: {
         readonly host: string;
         readonly port: number;
         readonly database: string;
@@ -194,7 +188,7 @@ export interface ResolvedValenceConfig {
         readonly query_timeout?: number | undefined;
         readonly sslmode: 'disable' | 'require' | 'verify-ca' | 'verify-full';
         readonly sslrootcert?: string | undefined;
-    };
+    } | undefined;
     // (undocumented)
     readonly graphql?: boolean | undefined;
     // (undocumented)
@@ -281,9 +275,9 @@ export interface ValenceConfig {
         readonly requireAuth?: boolean | undefined;
     } | undefined;
     // (undocumented)
-    readonly collections: ReadonlyArray<CollectionConfig>;
+    readonly collections?: ReadonlyArray<CollectionConfig> | undefined;
     // (undocumented)
-    readonly db: {
+    readonly db?: {
         readonly host: string;
         readonly port: number;
         readonly database: string;
@@ -295,7 +289,7 @@ export interface ValenceConfig {
         readonly query_timeout?: number | undefined;
         readonly sslmode?: 'disable' | 'require' | 'verify-ca' | 'verify-full' | undefined;
         readonly sslrootcert?: string | undefined;
-    };
+    } | undefined;
     // (undocumented)
     readonly graphql?: boolean | undefined;
     // (undocumented)
@@ -308,10 +302,10 @@ export interface ValenceConfig {
     // (undocumented)
     readonly routes?: readonly RouteConfig[] | undefined;
     // (undocumented)
-    readonly server: {
-        readonly port: number;
+    readonly server?: {
+        readonly port?: number | undefined;
         readonly host?: string | undefined;
-    };
+    } | undefined;
     // (undocumented)
     readonly stores?: readonly StoreInput[] | undefined;
     // (undocumented)


### PR DESCRIPTION
## The contract

A user shouldn't have to spin up a CMS, a database, or an admin panel they didn't ask for. This PR rewrites the CLI around one idea: **the config alone decides what boots**, and infrastructure is demanded only by features that need it — with refusals that name the feature.

## What changed

### `boot-plan.ts` (new, pure, 12-test matrix)
`planBoot(config)` derives: `mountCms` (collections exist), `mountAdmin` (CMS **and** an `admin` section — headless CMS is now a real mode), `mountGraphql`, `mountTelemetry`, `registerStores`, `needsDatabase` + **named `databaseReasons`**, and `requiresSecret` (CMS or non-page stores; a routes-only app needs no CMS_SECRET even in production).

### `defineConfig`
`db`, `server`, and `collections` are all optional. `defineConfig({})` is valid: port 3000, no database, no CMS. The db section is still fully validated when present.

### `valence dev` / `valence start`
Shared boot phases (`loadConfigAndPlan` → `provisionDatabase` → `buildCmsIfPlanned`) replace the duplicated setup. Config loads FIRST; `.env` is a fallback for the db (config `db` section wins — previously the config's db block was decorative and only `DB_*` was read). Pipeline gates: admin routes only when planned, REST only with a CMS, learn mode disabled without a database (with an honest message), stores/telemetry/graphql each gated. `PORT` env → config `server.port` → 3000. Boot test proves a routes-only app starts with **no database and no CMS_SECRET**; refusal test proves `collections` without a database exits naming `collections` + `database`.

### `valence init` — builds Valence apps only
- **Framework prompts removed entirely** (Astro et al. gone; source-guard test pins `/astro|react|frontend framework/i` out of cli.ts)
- New prompt: *"Include the CMS (database, collections, REST API)?"* → no (or `--minimal`) scaffolds routes + starter page + example loader route, `.env` without `DB_*`, no migrations, no compose file
- **Postgres set up properly when CMS is chosen**: `docker-compose.yml` (postgres:16-alpine, healthcheck, volume) wired to the exact answers; **connectivity verified with a real `SELECT 1` before migrations run**; unreachable → honest failure checklist pointing at `docker compose up -d`, then `valence migrate` / `valence user:create`
- **Admin user minted during init when the panel is chosen**: argon2id-hashed parameterized insert (`ON CONFLICT DO NOTHING`), CSPRNG default password, credentials printed exactly once in the summary
- Summary earns its optimism: no Admin URL for CMS-less projects, failures stay an honest checklist

### Types (pre-freeze, deliberate)
`LoaderContext.pool/cms`, `ActionContext.pool/cms`, `OnServerContext.pool/cms` are now `| null` — honest for database-less apps, TS forces handling. API report regenerated.

### Commands
`migrate` / `user:create` / `telemetry:aggregate` accept the db from `.env` **or** the config file and answer accurately when neither exists.

## Validation

- TDD: 4 RED→GREEN pairs (boot plan, defineConfig, init, boot gating) + REFACTOR; sequence check passes
- 37 new tests; full valence suite at exact parity with baseline (the 27 known Windows-host artifacts only, #352)
- Complexity kept under 20 by extraction, not suppression
- `docs/TROUBLESHOOTING.md`: the boot matrix (what each config section demands)
- tsc, eslint, banned-patterns green