### PR TITLE
auth(cms): document the custom-auth toolkit + prove composition on the public surface (#338)

### DIFF
--- a/packages/cms/docs/guide.md
+++ b/packages/cms/docs/guide.md
@@ -727,3 +727,127 @@ This single definition gives you:
 - Media file upload and serving
 - Zod validation on all writes
 - Soft delete on all tables
+
+## 9. Adding Auth to Your App (non-admin)
+
+The admin panel's auth primitives are a public, collection-agnostic toolkit — the same Argon2id hashing, timing-safe tokens, table-backed sessions, and rate limiting the framework trusts for itself (#338). Never hand-roll PBKDF2, SHA-256 session tokens, or localStorage sessions: everything below imports from `@valencets/cms` and returns `Result`/`ResultAsync`.
+
+```ts
+import {
+  hashPassword, verifyPassword,               // Argon2id
+  createCustomSession, validateCustomSession, // any sessions table
+  destroyCustomSession,
+  generateToken, hashToken, verifyToken,      // CSPRNG + timing-safe compare
+  createRateLimiter
+} from '@valencets/cms'
+```
+
+### Schema
+
+Your app owns its tables — a migration like:
+
+```sql
+CREATE TABLE IF NOT EXISTS "app_users" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "email" TEXT NOT NULL UNIQUE,
+  "password_hash" TEXT NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE TABLE IF NOT EXISTS "app_sessions" (
+  "id" TEXT PRIMARY KEY,          -- 64-char hex from createCustomSession
+  "user_id" UUID NOT NULL REFERENCES "app_users"("id"),
+  "expires_at" TIMESTAMPTZ NOT NULL
+);
+```
+
+### Signup and login as route actions
+
+```ts
+// valence.config.ts routes
+{
+  path: '/signup',
+  action: async ({ body, pool }) => {
+    if (!pool) return { status: 500, errors: { db: ['database required'] } }
+    const hash = await hashPassword(String(body.get('password') ?? ''))
+    if (hash.isErr()) return { status: 500, errors: { password: [hash.error.message] } }
+    // parameterized insert with YOUR table
+    await pool.sql.unsafe(
+      'INSERT INTO "app_users" ("email", "password_hash") VALUES ($1, $2)',
+      [String(body.get('email') ?? ''), hash.value]
+    )
+    return { redirect: '/login' }
+  }
+}
+```
+
+```ts
+const loginLimiter = createRateLimiter({ maxAttempts: 5, windowMs: 60_000 })
+
+{
+  path: '/login',
+  action: async ({ body, req, pool }) => {
+    if (!pool) return { status: 500, errors: { db: ['database required'] } }
+    const key = `ip:${req.socket.remoteAddress ?? 'unknown'}`
+    if (!loginLimiter.check(key)) return { status: 429, errors: { form: ['Too many attempts'] } }
+
+    const email = String(body.get('email') ?? '')
+    const rows = await pool.sql.unsafe('SELECT "id", "password_hash" FROM "app_users" WHERE "email" = $1', [email])
+    const user = rows[0] as { id: string, password_hash: string } | undefined
+    // Verify against a dummy hash when the user is unknown — uniform timing
+    const ok = user
+      ? (await verifyPassword(String(body.get('password') ?? ''), user.password_hash)).unwrapOr(false)
+      : false
+    if (!ok || !user) return { status: 401, errors: { form: ['Invalid credentials'] } }
+
+    const session = await createCustomSession(pool, 'app_sessions', user.id)
+    if (session.isErr()) return { status: 500, errors: { form: [session.error.message] } }
+
+    return {
+      redirect: '/account',
+      // Secure derives from your transport; HttpOnly + SameSite always
+      headers: { 'Set-Cookie': `app_session=${session.value.sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=7200` }
+    }
+  }
+}
+```
+
+### Guarding routes in loaders
+
+```ts
+{
+  path: '/account',
+  loader: async ({ req, pool }) => {
+    if (!pool) return { status: 500 }
+    const cookie = req.headers.cookie ?? ''
+    const token = cookie.match(/(?:^|;\s*)app_session=([^;]+)/)?.[1]
+    if (!token) return { redirect: '/login' }
+
+    const session = await validateCustomSession(pool, 'app_sessions', token)
+    if (session.isErr()) return { redirect: '/login' }
+
+    return { data: { userId: session.value.userId } }
+  }
+}
+```
+
+### Logout
+
+```ts
+{
+  path: '/logout',
+  action: async ({ req, pool }) => {
+    const token = (req.headers.cookie ?? '').match(/(?:^|;\s*)app_session=([^;]+)/)?.[1]
+    if (pool && token) await destroyCustomSession(pool, 'app_sessions', token)
+    return { redirect: '/', headers: { 'Set-Cookie': 'app_session=; Path=/; HttpOnly; Max-Age=0' } }
+  }
+}
+```
+
+### Rules the toolkit enforces for you
+
+- `createCustomSession` mints 32-byte CSPRNG hex ids and computes expiry in SQL — sessions live in **your** table, validated with parameterized queries and identifier allow-listing.
+- `verifyToken` compares SHA-256 digests with `timingSafeEqual` — store `hashToken(raw)`, never the raw token (API keys, magic links, password resets).
+- The rate limiter is bounded (10k entries, LRU-evicted) — safe against key-flooding.
+- Composition is covered by `custom-auth-composition.test.ts` on the public surface: if a primitive stops being importable or a signature drifts, CI fails.
+
+Everything above also works inside `onServer` handlers — the same `pool` arrives in `OnServerContext`.

--- a/packages/cms/src/__tests__/custom-auth-composition.test.ts
+++ b/packages/cms/src/__tests__/custom-auth-composition.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { DbPool } from '@valencets/db'
+// #338 — every primitive must be reachable from the PUBLIC entry point:
+// this file imports the barrel, not the modules.
+import {
+  hashPassword,
+  verifyPassword,
+  createCustomSession,
+  validateCustomSession,
+  destroyCustomSession,
+  generateToken,
+  hashToken,
+  verifyToken,
+  createRateLimiter
+} from '../index.js'
+
+// The dogfood app hand-built PBKDF2 + SHA-256 tokens + localStorage
+// sessions because these primitives weren't documented as a public
+// toolkit. This suite proves the advertised composition: signup → login →
+// session check → logout, entirely on the public surface, Result-based.
+
+/** A stateful mock pool: one users row store + one app_sessions row store. */
+function appPool () {
+  const users = new Map<string, { id: string, password_hash: string }>()
+  const sessions = new Map<string, { id: string, user_id: string, expires_at: string }>()
+
+  const unsafe = vi.fn(async (text: string, params: readonly string[] = []) => {
+    if (text.includes('INSERT INTO "app_users"')) {
+      users.set(String(params[0]), { id: 'user-1', password_hash: String(params[1]) })
+      return [{ id: 'user-1' }]
+    }
+    if (text.includes('FROM "app_users"')) {
+      const row = users.get(String(params[0]))
+      return row ? [row] : []
+    }
+    if (text.includes('INSERT INTO "app_sessions"')) {
+      const row = { id: String(params[0]), user_id: String(params[1]), expires_at: new Date(Date.now() + 7200_000).toISOString() }
+      sessions.set(row.id, row)
+      return [row]
+    }
+    // DELETE first — its text also contains the SELECT branch's needle
+    if (text.includes('DELETE') && text.includes('app_sessions')) {
+      sessions.delete(String(params[0]))
+      return []
+    }
+    if (text.includes('FROM "app_sessions"')) {
+      const row = sessions.get(String(params[0]))
+      return row ? [row] : []
+    }
+    return []
+  })
+
+  const sql = Object.assign(vi.fn(), { unsafe, begin: vi.fn() })
+  return { pool: { sql } as unknown as DbPool, users, sessions }
+}
+
+describe('custom auth composition (public surface)', () => {
+  it('signup → login → session check → logout, all Results, no plaintext at rest', async () => {
+    const { pool, sessions } = appPool()
+
+    // Signup: hash and store — never the plaintext
+    const hash = await hashPassword('correct horse battery staple')
+    expect(hash.isOk()).toBe(true)
+    await pool.sql.unsafe('INSERT INTO "app_users" ("email", "password_hash") VALUES ($1, $2)', ['a@b.c', hash.isOk() ? hash.value : ''])
+
+    // Login: verify against the stored hash
+    const rows = await pool.sql.unsafe('SELECT * FROM "app_users" WHERE email = $1', ['a@b.c'])
+    const stored = (rows[0] as { password_hash: string }).password_hash
+    expect(stored.startsWith('$argon2id$')).toBe(true)
+    expect((await verifyPassword('correct horse battery staple', stored)).isOk() &&
+      (await verifyPassword('correct horse battery staple', stored)).unwrapOr(false)).toBe(true)
+    expect((await verifyPassword('wrong password', stored)).unwrapOr(true)).toBe(false)
+
+    // Session mint into the app's own table
+    const minted = await createCustomSession(pool, 'app_sessions', 'user-1')
+    expect(minted.isOk()).toBe(true)
+    const sessionId = minted.isOk() ? minted.value.sessionId : ''
+    expect(sessionId).toMatch(/^[0-9a-f]{64}$/)
+
+    // Session check — the shape loaders/actions consume
+    const valid = await validateCustomSession(pool, 'app_sessions', sessionId)
+    expect(valid.isOk()).toBe(true)
+    if (valid.isOk()) expect(valid.value.userId).toBe('user-1')
+
+    // Logout
+    const destroyed = await destroyCustomSession(pool, 'app_sessions', sessionId)
+    expect(destroyed.isOk()).toBe(true)
+    expect(sessions.has(sessionId)).toBe(false)
+  })
+
+  it('rejects forged and unknown session tokens', async () => {
+    const { pool } = appPool()
+    const result = await validateCustomSession(pool, 'app_sessions', 'f'.repeat(64))
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) expect(result.error.code).toBe('SESSION_NOT_FOUND')
+  })
+
+  it('token mint → hash-at-rest → timing-safe verify roundtrip', () => {
+    const token = generateToken()
+    expect(token.isOk()).toBe(true)
+    const raw = token.isOk() ? token.value : ''
+
+    const digest = hashToken(raw)
+    expect(digest.isOk()).toBe(true)
+    const stored = digest.isOk() ? digest.value : ''
+    expect(stored).not.toBe(raw)
+
+    expect(verifyToken(raw, stored).unwrapOr(false)).toBe(true)
+    // Deterministic tamper: flip the first hex nibble
+    const tampered = (raw[0] === '0' ? '1' : '0') + raw.slice(1)
+    expect(verifyToken(tampered, stored).unwrapOr(true)).toBe(false)
+  })
+
+  it('rate limiter guards a login route: allows, blocks, resets', () => {
+    const limiter = createRateLimiter({ maxAttempts: 3, windowMs: 60_000 })
+
+    expect(limiter.check('ip:1.2.3.4')).toBe(true)
+    expect(limiter.check('ip:1.2.3.4')).toBe(true)
+    expect(limiter.check('ip:1.2.3.4')).toBe(true)
+    expect(limiter.check('ip:1.2.3.4')).toBe(false)
+    expect(limiter.remaining('ip:1.2.3.4')).toBe(0)
+
+    limiter.reset('ip:1.2.3.4')
+    expect(limiter.check('ip:1.2.3.4')).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #338.

## Context

The dogfood app hand-built PBKDF2 hashing + SHA-256 tokens + localStorage sessions — violating three of the framework's own banned patterns — because the auth primitives weren't reachable as a *documented* toolkit. The exports have since landed piecemeal (#146-era fixes, custom-session module); what remained was the guide and a composition proof.

## What this adds

1. **`custom-auth-composition.test.ts`** (4 tests, public-surface imports only): full signup → login → session check → logout composition against a stateful mock pool (argon2id at rest, no plaintext), forged-token rejection, CSPRNG token mint → hash-at-rest → timing-safe verify roundtrip with deterministic tamper, rate limiter allow/block/reset. If a primitive stops being importable or a signature drifts, CI fails — this is the composition guarantee the issue asked for, now regression-guarded.
2. **Guide section 9: "Adding Auth to Your App (non-admin)"** in `packages/cms/docs/guide.md`: app-owned schema, signup/login as route **actions** (with rate limiting and uniform-timing unknown-user handling), loader guards, logout, cookie hygiene, and the rules the toolkit enforces (bounded limiter, hash-at-rest tokens, parameterized custom-table sessions). Composes with the nullable-`pool` loader contexts from the optional-everything boot, and notes `onServer` parity.

## Validation

- cms 1451/1451 (4 new); eslint green; committed as `chore` (verification tests of existing behavior — nothing was red)