### PR TITLE
integrity(core): single cookie abstraction — one parser + serializer (#342)

### DIFF
--- a/packages/cms/cms.api.md
+++ b/packages/cms/cms.api.md
@@ -1265,7 +1265,7 @@ export interface PaginatedResult<T> {
     readonly totalPages: number;
 }
 
-// @public (undocumented)
+// @public
 export function parseCookie(cookieHeader: string, name: string): string | null;
 
 // @public (undocumented)

--- a/packages/cms/src/admin/admin-routes.ts
+++ b/packages/cms/src/admin/admin-routes.ts
@@ -33,7 +33,7 @@ import { generateConditionalSchema, generateConditionalPartialSchema } from '../
 import { setFlashCookie, readFlash, clearFlashCookie } from './flash.js'
 import { readFileSync } from 'node:fs'
 import { basename, resolve } from 'node:path'
-import { generateNonce, setSecurityHeaders, CSP_NONCE_PLACEHOLDER, generateCsrfToken, validateCsrfToken } from '@valencets/core/server'
+import { generateNonce, setSecurityHeaders, CSP_NONCE_PLACEHOLDER, generateCsrfToken, validateCsrfToken, isSecureTransport } from '@valencets/core/server'
 import { fileURLToPath } from 'node:url'
 
 export type AdminRouteHandler = (req: IncomingMessage, res: ServerResponse, ctx: Record<string, string>) => Promise<void>
@@ -308,7 +308,7 @@ export function createAdminRoutes (
         return
       }
       loginLimiter.reset(ip)
-      const secure = !!(req.socket as { encrypted?: boolean }).encrypted
+      const secure = isSecureTransport(req)
       res.setHeader('Set-Cookie', buildSessionCookie(sessionResult.value, sessionMaxAge, secure))
       res.writeHead(302, { Location: '/admin' })
       res.end()
@@ -326,7 +326,7 @@ export function createAdminRoutes (
       if (sessionId) {
         await destroySession(sessionId, pool)
       }
-      const secure = !!(req.socket as { encrypted?: boolean }).encrypted
+      const secure = isSecureTransport(req)
       res.setHeader('Set-Cookie', buildExpiredSessionCookie(secure))
       res.writeHead(302, { Location: '/admin/login' })
       res.end()

--- a/packages/cms/src/admin/flash.ts
+++ b/packages/cms/src/admin/flash.ts
@@ -1,5 +1,6 @@
 import type { ServerResponse } from 'node:http'
 import { fromThrowable } from '@valencets/resultkit'
+import { serializeCookie } from '@valencets/core/server'
 import { parseCookie } from '../auth/cookie.js'
 
 interface FlashMessage {
@@ -29,11 +30,11 @@ function parseFlash (encoded: string): FlashMessage | null {
 
 function setFlashCookie (res: ServerResponse, msg: FlashMessage): void {
   const value = serializeFlash(msg)
-  res.setHeader('Set-Cookie', `cms_flash=${value}; Path=/admin; HttpOnly; SameSite=Lax; Secure; Max-Age=30`)
+  res.setHeader('Set-Cookie', serializeCookie('cms_flash', value, { path: '/admin', httpOnly: true, sameSite: 'Lax', secure: true, maxAge: 30 }))
 }
 
 function clearFlashCookie (res: ServerResponse): void {
-  res.setHeader('Set-Cookie', 'cms_flash=; Path=/admin; HttpOnly; SameSite=Lax; Secure; Max-Age=0')
+  res.setHeader('Set-Cookie', serializeCookie('cms_flash', '', { path: '/admin', httpOnly: true, sameSite: 'Lax', secure: true, maxAge: 0 }))
 }
 
 function readFlash (cookieHeader: string): FlashMessage | null {

--- a/packages/cms/src/auth/auth-routes.ts
+++ b/packages/cms/src/auth/auth-routes.ts
@@ -3,21 +3,17 @@ import type { CmsError } from '../schema/types.js'
 import type { DbPool } from '@valencets/db'
 import type { CollectionRegistry } from '../schema/registry.js'
 import type { RestRouteEntry } from '../api/rest-api.js'
-import type { IncomingMessage } from 'node:http'
 import type { DocumentData } from '../db/query-builder.js'
 import { z } from 'zod'
 import { sendApiJson, sendErrorJson, safeReadBody, safeJsonParse } from '../api/http-utils.js'
 import { verifyPassword } from './password.js'
 import { createRateLimiter } from './rate-limit.js'
 import { parseCookie } from './cookie.js'
+import { serializeCookie, isSecureTransport } from '@valencets/core/server'
 import { safeQuery } from '../db/safe-query.js'
 import { createSession, validateSession, destroySession, destroyUserSessions, buildSessionCookie, buildExpiredSessionCookie } from './session.js'
 import { sanitizeIdentifier, isValidIdentifier } from '../db/sql-sanitize.js'
 import { isAuthEnabled } from './auth-config.js'
-
-function isEncrypted (req: IncomingMessage): boolean {
-  return !!(req.socket as { encrypted?: boolean }).encrypted
-}
 
 interface UserRow {
   readonly id: string
@@ -101,11 +97,10 @@ export function createAuthRoutes (
       const sessionResult = await createSession(user.id, pool)
       if (sessionResult.isErr()) { sendErrorJson(res, 'Login failed', 500); return }
 
-      const secure = isEncrypted(req)
+      const secure = isSecureTransport(req)
       const sessionCookie = buildSessionCookie(sessionResult.value, 7200, secure)
       // Set both the HttpOnly session cookie and a JS-readable indicator cookie
-      const secureFlag = secure ? '; Secure' : ''
-      const indicatorCookie = `cms_authed=1; Path=/; SameSite=Lax${secureFlag}; Max-Age=7200`
+      const indicatorCookie = serializeCookie('cms_authed', '1', { path: '/', sameSite: 'Lax', secure, maxAge: 7200 })
       res.writeHead(200, {
         'Content-Type': 'application/json; charset=utf-8',
         'Set-Cookie': [sessionCookie, indicatorCookie]
@@ -125,10 +120,10 @@ export function createAuthRoutes (
       if (sessionId) {
         await destroySession(sessionId, pool)
       }
-      const secure = isEncrypted(req)
+      const secure = isSecureTransport(req)
       res.writeHead(200, {
         'Content-Type': 'application/json; charset=utf-8',
-        'Set-Cookie': [buildExpiredSessionCookie(secure), `cms_authed=; Path=/; SameSite=Lax${secure ? '; Secure' : ''}; Max-Age=0`]
+        'Set-Cookie': [buildExpiredSessionCookie(secure), serializeCookie('cms_authed', '', { path: '/', sameSite: 'Lax', secure, maxAge: 0 })]
       })
       res.end(JSON.stringify({ message: 'Logged out' }))
     }

--- a/packages/cms/src/auth/cookie.ts
+++ b/packages/cms/src/auth/cookie.ts
@@ -1,7 +1,11 @@
+import { getCookie } from '@valencets/core/server'
+
+/**
+ * Read a single cookie value, or null when absent. Thin adapter over the
+ * framework's one cookie parser (#342) so CMS callers keep their
+ * null-returning contract while parsing stays centralized and literal
+ * (prefix- and regex-metacharacter-safe).
+ */
 export function parseCookie (cookieHeader: string, name: string): string | null {
-  const match = cookieHeader.split(';')
-    .map(c => c.trim())
-    .find(c => c.startsWith(`${name}=`))
-  if (!match) return null
-  return match.slice(name.length + 1)
+  return getCookie(cookieHeader, name) ?? null
 }

--- a/packages/cms/src/auth/session.ts
+++ b/packages/cms/src/auth/session.ts
@@ -1,5 +1,6 @@
 import { errAsync, okAsync } from '@valencets/resultkit'
 import type { ResultAsync } from '@valencets/resultkit'
+import { serializeCookie } from '@valencets/core/server'
 import type { DbPool } from '@valencets/db'
 import { CmsErrorCode } from '../schema/types.js'
 import type { CmsError } from '../schema/types.js'
@@ -53,13 +54,11 @@ export function validateSession (sessionId: string, pool: DbPool): ResultAsync<s
 }
 
 export function buildSessionCookie (sessionId: string, maxAgeSeconds = DEFAULT_SESSION_MAX_AGE, secure = true): string {
-  const secureFlag = secure ? '; Secure' : ''
-  return `cms_session=${sessionId}; Path=/; HttpOnly; SameSite=Lax${secureFlag}; Max-Age=${maxAgeSeconds}`
+  return serializeCookie('cms_session', sessionId, { path: '/', httpOnly: true, sameSite: 'Lax', secure, maxAge: maxAgeSeconds })
 }
 
 export function buildExpiredSessionCookie (secure = true): string {
-  const secureFlag = secure ? '; Secure' : ''
-  return `cms_session=; Path=/; HttpOnly; SameSite=Lax${secureFlag}; Max-Age=0`
+  return serializeCookie('cms_session', '', { path: '/', httpOnly: true, sameSite: 'Lax', secure, maxAge: 0 })
 }
 
 export function destroyUserSessions (userId: string, pool: DbPool): ResultAsync<void, CmsError> {

--- a/packages/core/core.api.md
+++ b/packages/core/core.api.md
@@ -132,6 +132,20 @@ export const ContentCategory: Readonly<{
 export type ContentCategory = typeof ContentCategory[keyof typeof ContentCategory];
 
 // @public (undocumented)
+export interface CookieOptions {
+    // (undocumented)
+    readonly domain?: string;
+    // (undocumented)
+    readonly httpOnly?: boolean;
+    readonly maxAge?: number;
+    // (undocumented)
+    readonly path?: string;
+    // (undocumented)
+    readonly sameSite?: SameSite;
+    readonly secure?: boolean;
+}
+
+// @public (undocumented)
 export interface CorsConfig {
     // (undocumented)
     readonly credentials?: boolean;
@@ -255,6 +269,9 @@ export function generateCsrfToken(): string;
 // @public (undocumented)
 export function generateNonce(): string;
 
+// @public
+export function getCookie(header: string | undefined, name: string): string | undefined;
+
 // @public (undocumented)
 export function getCsrfToken(): string | undefined;
 
@@ -376,6 +393,9 @@ export interface IslandHtmlOptions {
     // (undocumented)
     readonly maxAge?: number;
 }
+
+// @public
+export function isSecureTransport(req: IncomingMessage): boolean;
 
 // @public (undocumented)
 export function isValidBeaconUrl(url: string): boolean;
@@ -540,6 +560,9 @@ export interface PageCacheHandle {
     // (undocumented)
     readonly size: () => number;
 }
+
+// @public
+export function parseCookies(header: string | undefined): Readonly<Record<string, string>>;
 
 // @public (undocumented)
 export function parseHtml(html: string): Result<Document, RouterError>;
@@ -792,6 +815,9 @@ export function routeUrl(path: string, params: Record<string, string>): string;
 // @public
 export function safeRedirect(url: string, fallback?: string): string;
 
+// @public
+export type SameSite = 'Strict' | 'Lax' | 'None';
+
 // @public (undocumented)
 export function scheduleAutoFlush(buffer: TelemetryRingBuffer, endpointUrl: string, intervalMs?: number, onFlush?: (count: number) => void): Result<FlushHandle, TelemetryError>;
 
@@ -827,6 +853,9 @@ export function sendIslandHtml(res: ServerResponse, html: string, options?: Isla
 
 // @public (undocumented)
 export function sendJson(res: ServerResponse, data: JsonValue, statusCode?: number): void;
+
+// @public
+export function serializeCookie(name: string, value: string, options?: CookieOptions): string;
 
 // @public (undocumented)
 export function serializeForm(form: HTMLFormElement): URLSearchParams;

--- a/packages/core/src/router/fragment-swap.ts
+++ b/packages/core/src/router/fragment-swap.ts
@@ -2,6 +2,9 @@ import { ok, err } from '@valencets/resultkit'
 import type { Result } from '@valencets/resultkit'
 import { RouterErrorCode } from './router-types.js'
 import type { RouterError } from './router-types.js'
+// The cookie parser is isomorphic — its only node import is a type, erased at
+// build — so the client bundle stays free of server runtime.
+import { getCookie } from '../server/cookies.js'
 
 function hasMoveBefore (target: Element): target is Element & { moveBefore (node: Node, ref: Node | null): void } {
   return typeof (target as { moveBefore?: Function }).moveBefore === 'function'
@@ -121,12 +124,5 @@ export function stripScripts (doc: Document, nonce?: string): void {
 }
 
 export function getCsrfToken (): string | undefined {
-  const cookies = document.cookie.split(';')
-  for (const raw of cookies) {
-    const trimmed = raw.trim()
-    if (trimmed.startsWith('__val_csrf=')) {
-      return trimmed.slice('__val_csrf='.length)
-    }
-  }
-  return undefined
+  return getCookie(document.cookie, '__val_csrf')
 }

--- a/packages/core/src/server/__tests__/cookies.test.ts
+++ b/packages/core/src/server/__tests__/cookies.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import type { IncomingMessage } from 'node:http'
+import { parseCookies, getCookie, serializeCookie, isSecureTransport } from '../cookies.js'
+
+describe('parseCookies()', () => {
+  it('returns an empty map for undefined or empty headers', () => {
+    expect(parseCookies(undefined)).toEqual({})
+    expect(parseCookies('')).toEqual({})
+    expect(parseCookies('   ')).toEqual({})
+  })
+
+  it('parses a single name=value pair', () => {
+    expect(parseCookies('session_id=abc123')).toEqual({ session_id: 'abc123' })
+  })
+
+  it('parses multiple pairs separated by "; "', () => {
+    expect(parseCookies('a=1; b=2; c=3')).toEqual({ a: '1', b: '2', c: '3' })
+  })
+
+  it('tolerates arbitrary surrounding whitespace', () => {
+    expect(parseCookies('  a = 1 ;b=2   ; c=3')).toEqual({ a: '1', b: '2', c: '3' })
+  })
+
+  it('preserves "=" characters inside the value (e.g. base64url padding)', () => {
+    expect(parseCookies('token=YWJj==')).toEqual({ token: 'YWJj==' })
+  })
+
+  it('keeps the first occurrence when a name repeats', () => {
+    expect(parseCookies('dup=first; dup=second')).toEqual({ dup: 'first' })
+  })
+
+  it('skips malformed segments that carry no "="', () => {
+    expect(parseCookies('a=1; garbage; b=2')).toEqual({ a: '1', b: '2' })
+  })
+
+  it('is not fooled by a name that is a prefix of another cookie', () => {
+    const parsed = parseCookies('session_id_backup=wrong; session_id=right')
+    expect(parsed.session_id).toBe('right')
+  })
+})
+
+describe('getCookie()', () => {
+  it('returns the value for a present cookie', () => {
+    expect(getCookie('a=1; cms_session=xyz', 'cms_session')).toBe('xyz')
+  })
+
+  it('returns undefined for an absent cookie or empty header', () => {
+    expect(getCookie('a=1', 'b')).toBeUndefined()
+    expect(getCookie(undefined, 'a')).toBeUndefined()
+    expect(getCookie('', 'a')).toBeUndefined()
+  })
+
+  it('does not match a cookie whose name is only a prefix of the requested one', () => {
+    expect(getCookie('session=short', 'session_id')).toBeUndefined()
+  })
+
+  it('does not match a longer cookie name that starts with the requested one', () => {
+    // The classic prefix bug: reading "session_id" must not return "session_id_backup".
+    expect(getCookie('session_id_backup=wrong; session_id=right', 'session_id')).toBe('right')
+  })
+
+  it('treats the requested name literally, not as a regular expression', () => {
+    // A naive `new RegExp(name + '=')` would let "a.b" match "axb=2".
+    expect(getCookie('axb=2; a.b=1', 'a.b')).toBe('1')
+    expect(getCookie('axb=2', 'a.b')).toBeUndefined()
+  })
+})
+
+describe('serializeCookie()', () => {
+  it('serializes a bare name=value with no attributes', () => {
+    expect(serializeCookie('a', '1')).toBe('a=1')
+  })
+
+  it('emits the standard attribute set when requested', () => {
+    const cookie = serializeCookie('cms_session', 'abc', {
+      path: '/',
+      maxAge: 7200,
+      httpOnly: true,
+      sameSite: 'Lax',
+      secure: true
+    })
+    expect(cookie).toContain('cms_session=abc')
+    expect(cookie).toContain('Path=/')
+    expect(cookie).toContain('Max-Age=7200')
+    expect(cookie).toContain('HttpOnly')
+    expect(cookie).toContain('SameSite=Lax')
+    expect(cookie).toContain('Secure')
+  })
+
+  it('omits HttpOnly and Secure when their flags are false', () => {
+    const cookie = serializeCookie('a', '1', { httpOnly: false, secure: false, sameSite: 'Lax' })
+    expect(cookie).not.toContain('HttpOnly')
+    expect(cookie).not.toContain('Secure')
+    expect(cookie).toContain('SameSite=Lax')
+  })
+
+  it('emits Max-Age=0 for an expiring cookie', () => {
+    expect(serializeCookie('a', '', { maxAge: 0, path: '/' })).toContain('Max-Age=0')
+  })
+
+  it('supports a Domain attribute', () => {
+    expect(serializeCookie('a', '1', { domain: 'example.com' })).toContain('Domain=example.com')
+  })
+})
+
+describe('isSecureTransport()', () => {
+  const reqWith = (socket: unknown): IncomingMessage =>
+    ({ socket } as unknown as IncomingMessage)
+
+  it('reports true when the underlying socket is TLS-encrypted', () => {
+    expect(isSecureTransport(reqWith({ encrypted: true }))).toBe(true)
+  })
+
+  it('reports false for a plaintext socket', () => {
+    expect(isSecureTransport(reqWith({ encrypted: false }))).toBe(false)
+    expect(isSecureTransport(reqWith({}))).toBe(false)
+  })
+
+  it('reports false when the socket is missing', () => {
+    expect(isSecureTransport(reqWith(undefined))).toBe(false)
+  })
+})
+
+describe('cookie round-trip properties', () => {
+  const rand = (n: number): number => Math.floor(Math.random() * n)
+  const nameChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_'
+  // Cookie values may include most token/base64url bytes; exclude the ';'
+  // delimiter and whitespace which are not valid unquoted cookie-octets.
+  const valueChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.=/+'
+
+  const pick = (alphabet: string, len: number): string => {
+    let out = ''
+    for (let i = 0; i < len; i++) out += alphabet[rand(alphabet.length)]
+    return out
+  }
+
+  it('reads back any single serialized name=value pair', () => {
+    for (let i = 0; i < 300; i++) {
+      const name = pick(nameChars, 1 + rand(24))
+      const value = pick(valueChars, rand(40))
+      const header = serializeCookie(name, value).split(';')[0] ?? ''
+      expect(getCookie(header, name)).toBe(value)
+    }
+  })
+
+  it('parses every pair back out of a multi-cookie header with unique names', () => {
+    for (let iter = 0; iter < 100; iter++) {
+      const pairs = new Map<string, string>()
+      const count = 1 + rand(8)
+      for (let i = 0; i < count; i++) {
+        pairs.set(`c${i}_${pick(nameChars, 4)}`, pick(valueChars, rand(20)))
+      }
+      const header = [...pairs].map(([n, v]) => `${n}=${v}`).join('; ')
+      const parsed = parseCookies(header)
+      for (const [n, v] of pairs) {
+        expect(parsed[n]).toBe(v)
+        expect(getCookie(header, n)).toBe(v)
+      }
+    }
+  })
+})

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -1,0 +1,95 @@
+import type { IncomingMessage } from 'node:http'
+
+/**
+ * The single cookie abstraction (#342). Every parser and serializer in the
+ * framework routes through here so that quoting, prefix matching, and the
+ * standard attribute set live in exactly one audited place — the surface
+ * where subtle cookie security bugs otherwise breed.
+ *
+ * Parsing is literal (a name is a name, never a regular expression) and
+ * first-occurrence-wins, matching browser semantics. Serialization emits a
+ * fixed, safe attribute order; ordering is cosmetic to clients but keeps
+ * output deterministic for tests and diffs.
+ */
+
+export type SameSite = 'Strict' | 'Lax' | 'None'
+
+export interface CookieOptions {
+  readonly path?: string
+  readonly domain?: string
+  /** Lifetime in seconds. `0` expires the cookie immediately. */
+  readonly maxAge?: number
+  readonly httpOnly?: boolean
+  /** Set from the transport — see {@link isSecureTransport}. */
+  readonly secure?: boolean
+  readonly sameSite?: SameSite
+}
+
+/** Split a `name` off a single trimmed `name=value` segment, or null. */
+function splitPair (segment: string): readonly [string, string] | null {
+  const trimmed = segment.trim()
+  const eq = trimmed.indexOf('=')
+  if (eq <= 0) return null
+  const name = trimmed.slice(0, eq).trim()
+  if (name === '') return null
+  return [name, trimmed.slice(eq + 1).trim()]
+}
+
+/**
+ * Parse a `Cookie` request header into a name→value map. First occurrence
+ * wins; malformed segments (no `=`) are skipped. Returns an empty object for
+ * an absent or blank header.
+ */
+export function parseCookies (header: string | undefined): Readonly<Record<string, string>> {
+  const out: Record<string, string> = {}
+  if (header === undefined || header === '') return out
+  for (const segment of header.split(';')) {
+    const pair = splitPair(segment)
+    if (pair === null) continue
+    const [name, value] = pair
+    if (!Object.prototype.hasOwnProperty.call(out, name)) {
+      out[name] = value
+    }
+  }
+  return out
+}
+
+/**
+ * Read a single cookie value by exact name, or `undefined` when absent.
+ * The name is matched literally, so it is immune to the prefix- and
+ * regular-expression-metacharacter pitfalls of ad-hoc parsers.
+ */
+export function getCookie (header: string | undefined, name: string): string | undefined {
+  if (header === undefined || header === '') return undefined
+  for (const segment of header.split(';')) {
+    const pair = splitPair(segment)
+    if (pair === null) continue
+    if (pair[0] === name) return pair[1]
+  }
+  return undefined
+}
+
+/**
+ * Serialize a `Set-Cookie` header value with a fixed attribute order:
+ * `name=value; Path; Domain; Max-Age; HttpOnly; SameSite; Secure`.
+ */
+export function serializeCookie (name: string, value: string, options?: CookieOptions): string {
+  let out = `${name}=${value}`
+  if (options === undefined) return out
+  if (options.path !== undefined) out += `; Path=${options.path}`
+  if (options.domain !== undefined) out += `; Domain=${options.domain}`
+  if (options.maxAge !== undefined) out += `; Max-Age=${options.maxAge}`
+  if (options.httpOnly === true) out += '; HttpOnly'
+  if (options.sameSite !== undefined) out += `; SameSite=${options.sameSite}`
+  if (options.secure === true) out += '; Secure'
+  return out
+}
+
+/**
+ * Derive the `Secure` flag from the request transport: true only when the
+ * connection terminates TLS at this process. Proxy headers are deliberately
+ * ignored — a spoofable `X-Forwarded-Proto` must never mark a cookie Secure.
+ */
+export function isSecureTransport (req: IncomingMessage): boolean {
+  return (req.socket as { encrypted?: boolean } | undefined)?.encrypted === true
+}

--- a/packages/core/src/server/csrf-middleware.ts
+++ b/packages/core/src/server/csrf-middleware.ts
@@ -1,5 +1,6 @@
 import type { Middleware } from './middleware-types.js'
 import { generateCsrfToken, validateCsrfToken } from './csrf.js'
+import { getCookie, serializeCookie } from './cookies.js'
 import { sendJson, readBody } from './http-helpers.js'
 import { fromThrowable } from '@valencets/resultkit'
 
@@ -17,19 +18,6 @@ const safeDecodeFormComponent = fromThrowable(
   (value: string) => decodeURIComponent(value.replace(/\+/g, ' ')),
   () => undefined
 )
-
-function parseCookieValue (cookieHeader: string | undefined, name: string): string | undefined {
-  if (cookieHeader === undefined) return undefined
-  const prefix = `${name}=`
-  const cookies = cookieHeader.split(';')
-  for (const raw of cookies) {
-    const trimmed = raw.trim()
-    if (trimmed.startsWith(prefix)) {
-      return trimmed.slice(prefix.length)
-    }
-  }
-  return undefined
-}
 
 function extractBodyField (body: string, field: string): string | undefined {
   const pairs = body.split('&')
@@ -50,11 +38,11 @@ function extractBodyField (body: string, field: string): string | undefined {
 export function createCsrfMiddleware (): Middleware {
   return async (req, res, ctx, next) => {
     const cookieHeader = req.headers.cookie
-    const existingToken = parseCookieValue(cookieHeader, COOKIE_NAME)
+    const existingToken = getCookie(cookieHeader, COOKIE_NAME)
 
     if (existingToken === undefined) {
       const newToken = generateCsrfToken()
-      res.setHeader('Set-Cookie', `${COOKIE_NAME}=${newToken}; SameSite=Strict; Path=/`)
+      res.setHeader('Set-Cookie', serializeCookie(COOKIE_NAME, newToken, { path: '/', sameSite: 'Strict' }))
     }
 
     const method = req.method ?? 'GET'

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -24,6 +24,8 @@ export { createBodyLimitMiddleware, ContentCategory, resolveContentCategory } fr
 export type { BodyLimitConfig } from './body-limit.js'
 export { resolveTimeoutConfig, applyTimeouts } from './timeout-config.js'
 export type { TimeoutConfig, ResolvedTimeoutConfig } from './timeout-config.js'
+export { parseCookies, getCookie, serializeCookie, isSecureTransport } from './cookies.js'
+export type { CookieOptions, SameSite } from './cookies.js'
 export { generateCsrfToken, validateCsrfToken } from './csrf.js'
 export { createCsrfMiddleware } from './csrf-middleware.js'
 export { createOriginCheck } from './origin-check.js'

--- a/packages/valence/src/store-session.ts
+++ b/packages/valence/src/store-session.ts
@@ -1,4 +1,5 @@
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { serializeCookie } from '@valencets/core/server'
 
 /**
  * Signed anonymous store sessions. The server mints `id.signature` tokens
@@ -39,5 +40,5 @@ export function buildStoreSessionCookie (token: string, secure = false): string 
   // Secure mirrors the cms session cookie: derived from the transport, so
   // TLS deployments never leak the token over plaintext while local http
   // development keeps working.
-  return `session_id=${token}; Path=/; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`
+  return serializeCookie('session_id', token, { path: '/', httpOnly: true, sameSite: 'Lax', secure })
 }

--- a/packages/valence/src/store-wiring.ts
+++ b/packages/valence/src/store-wiring.ts
@@ -6,6 +6,7 @@ import type { StorePool, StateBackend } from '@valencets/store/server'
 import type { MutationPool } from '@valencets/store'
 import type { DbPool } from '@valencets/db'
 import { validateSession } from '@valencets/cms'
+import { getCookie, isSecureTransport } from '@valencets/core/server'
 import type { RouteHandler } from './define-config.js'
 import { mintSignedSessionId, verifySignedSessionId, buildStoreSessionCookie } from './store-session.js'
 import { fromThrowable, ok, err } from '@valencets/resultkit'
@@ -53,10 +54,11 @@ function readJsonBody (req: IncomingMessage): Promise<Result<string, BodyError>>
   })
 }
 
+// Delegates to the framework's one cookie parser (#342): literal matching,
+// no regex construction from the (caller-fixed) name. Keeps the null-return
+// contract the identity resolution below relies on.
 function readCookie (req: IncomingMessage, name: string): string | null {
-  const cookie = req.headers.cookie ?? ''
-  const match = cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`))
-  return match && match[1] ? match[1] : null
+  return getCookie(req.headers.cookie, name) ?? null
 }
 
 function readSessionToken (req: IncomingMessage): string | null {
@@ -109,7 +111,7 @@ async function resolveIdentity (
   }
 
   const minted = mintSignedSessionId(secret)
-  const secureTransport = !!((req.socket as { encrypted?: boolean } | undefined)?.encrypted)
+  const secureTransport = isSecureTransport(req)
   res.setHeader('Set-Cookie', buildStoreSessionCookie(minted, secureTransport))
   const dot = minted.indexOf('.')
   return { id: minted.slice(0, dot) }


### PR DESCRIPTION
## Why

Three independent cookie parsers had drifted apart — `cms/auth/cookie.ts` (split/find), `core/server/csrf-middleware.ts` (split/startsWith), and `valence/store-wiring.ts` (**`new RegExp(name)`**, which treats the cookie name as a pattern and is prefix-fragile) — plus a fourth client-side reader in `router/fragment-swap.ts` and **five** hand-written `Set-Cookie` serializers (session, expired-session, flash set/clear, `cms_authed`, store-session, CSRF). Duplicated cookie parsing/serialization is exactly where quoting, prefix-matching, and attribute bugs breed (#342).

## What

- New **`@valencets/core/server` cookie module** (`packages/core/src/server/cookies.ts`), additive public API:
  - `parseCookies(header)` → name→value map (first-occurrence-wins, malformed segments skipped)
  - `getCookie(header, name)` → single value, **literal** name matching (prefix- and regex-metacharacter-safe)
  - `serializeCookie(name, value, options)` → `Set-Cookie` value with a fixed, safe attribute order (`Path/Domain/Max-Age/HttpOnly/SameSite/Secure`)
  - `isSecureTransport(req)` → derive `Secure` from the TLS socket only; spoofable proxy headers are deliberately ignored
- **Migrated every call site** onto it while preserving public signatures:
  - core: `csrf-middleware` (parse + Set-Cookie), `fragment-swap.getCsrfToken` (client; the module's only `node:http` import is type-only and erased, so the client bundle stays clean)
  - cms: `auth/cookie.parseCookie` (delegates, keeps `string | null`), `session` builders, `admin/flash` set/clear, `auth-routes` (`cms_authed` + `isSecureTransport`), `admin-routes` (`isSecureTransport`)
  - valence: `store-session.buildStoreSessionCookie`, `store-wiring.readCookie` (deletes the unescaped-regex parser) + `isSecureTransport`
- Removed the three duplicate `(req.socket as {encrypted?}).encrypted` transport checks.

## Tests

- `packages/core/src/server/__tests__/cookies.test.ts` — edge cases (prefix safety, regex-metachar names, `=`-in-value, first-wins, malformed segments) + **randomized round-trip property tests** (single + multi-cookie).
- All existing cms/core/valence unit suites for the migrated code pass unchanged; behavior is preserved (attribute presence asserted via `toContain`).

## Validation

- `pnpm build` (full typecheck), `pnpm lint`, `bash scripts/check-banned-patterns.sh` — green
- `bash scripts/check-tdd-commit-sequence.sh range origin/development..HEAD` — green (RED → GREEN → REFACTOR)
- `PGPORT=55432 npx vitest run tests/integration/` — **58/58 green** (proves the real auth + store cookie flows still round-trip)
- API surface: `core.api.md` updated for the additive exports; `cms.api.md` diff is a benign `@public` doc annotation only (signature unchanged).

_Windows host: the ~31 known #352 path/CRLF test artifacts remain; CI on Ubuntu is authoritative._

Closes #342.