### PR TITLE
chore(tooling): Windows dev-host test artifacts — POSIX path/CRLF assumptions (#352)

### DIFF
--- a/packages/core/src/router/__tests__/form-enhance.test.ts
+++ b/packages/core/src/router/__tests__/form-enhance.test.ts
@@ -297,7 +297,9 @@ describe('initFormEnhancement', () => {
 
   it('does not use a raw promise catch in form enhancement', async () => {
     const { readFileSync } = await import('node:fs')
-    const source = readFileSync(`${process.cwd()}/src/router/form-enhance.ts`, 'utf-8')
+    // Normalize CRLF → LF so the multi-line substring assertion below is
+    // host-independent on Windows checkouts (#352).
+    const source = readFileSync(`${process.cwd()}/src/router/form-enhance.ts`, 'utf-8').replace(/\r\n/g, '\n')
     expect(source).toContain('ResultAsync.fromPromise(\n    submitEnhancedForm')
     expect(source).not.toMatch(/fetchFn\(url, \{ method, headers, body \}\)\s*\.then/)
     expect(source).not.toMatch(/\.catch\(/)

--- a/packages/core/src/router/__tests__/push-state.test.ts
+++ b/packages/core/src/router/__tests__/push-state.test.ts
@@ -1228,7 +1228,9 @@ describe('auth redirect handling', () => {
 
   it('does not use a raw promise catch in background revalidation', async () => {
     const { readFileSync } = await import('node:fs')
-    const source = readFileSync('src/router/push-state.ts', 'utf-8')
+    // Normalize CRLF → LF so the multi-line substring assertion below is
+    // host-independent on Windows checkouts (#352).
+    const source = readFileSync('src/router/push-state.ts', 'utf-8').replace(/\r\n/g, '\n')
     expect(source).not.toMatch(/function revalidateInBackground[\s\S]*?\.catch\(/)
     expect(source).toContain('ResultAsync.fromPromise(\n    runBackgroundRevalidation')
   })

--- a/packages/core/src/server/__tests__/static-files.test.ts
+++ b/packages/core/src/server/__tests__/static-files.test.ts
@@ -31,8 +31,13 @@ describe('resolveMimeType', () => {
   })
 })
 
+// The containment check joins with POSIX '/', so the Ok-path output is
+// POSIX-shaped; assert exact output only on POSIX hosts (CI runs it). The
+// traversal/rejection cases below are platform-agnostic and always run (#352).
+const isWindows = process.platform === 'win32'
+
 describe('resolveStaticPath', () => {
-  it('returns Ok for valid path within root', () => {
+  it.skipIf(isWindows)('returns Ok for valid path within root', () => {
     const result = resolveStaticPath('/styles.css', '/srv/public')
     expect(result.isOk()).toBe(true)
     expect(result.unwrap()).toBe('/srv/public/styles.css')
@@ -48,7 +53,7 @@ describe('resolveStaticPath', () => {
     expect(result.isErr()).toBe(true)
   })
 
-  it('normalizes slashes', () => {
+  it.skipIf(isWindows)('normalizes slashes', () => {
     const result = resolveStaticPath('/assets/css/main.css', '/srv/public')
     expect(result.isOk()).toBe(true)
     expect(result.unwrap()).toBe('/srv/public/assets/css/main.css')

--- a/packages/valence/src/__tests__/cli.test.ts
+++ b/packages/valence/src/__tests__/cli.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
 import { run } from '../cli.js'
+
+// Resolve a sibling source file cross-platform: URL.pathname yields
+// "/C:/..." on Windows, which fs cannot open — fileURLToPath fixes it (#352).
+const sourcePath = (relative: string): string => fileURLToPath(new URL(relative, import.meta.url))
 
 describe('CLI', () => {
   it('prints usage when no command given', async () => {
@@ -62,7 +67,7 @@ describe('CLI path normalization', () => {
 
   it('does not keep a request-derived redirect sink in the CLI server', async () => {
     const { readFileSync } = await import('node:fs')
-    const cliSource = readFileSync(new URL('../cli.ts', import.meta.url).pathname.replace('/dist/', '/src/'), 'utf-8')
+    const cliSource = readFileSync(sourcePath('../cli.ts'), 'utf-8')
     expect(cliSource).not.toContain('resolveSafeLocalRedirectTarget')
     expect(cliSource).not.toMatch(/Location:\s*redirectTarget/)
   })
@@ -71,8 +76,8 @@ describe('CLI path normalization', () => {
 describe('CLI security', () => {
   it('does not use execSync with string concatenation for tsx script execution', async () => {
     const { readFileSync } = await import('node:fs')
-    const cliSource = readFileSync(new URL('../cli.ts', import.meta.url).pathname.replace('/dist/', '/src/'), 'utf-8')
-    const loaderSource = readFileSync(new URL('../config-loader.ts', import.meta.url).pathname.replace('/dist/', '/src/'), 'utf-8')
+    const cliSource = readFileSync(sourcePath('../cli.ts'), 'utf-8')
+    const loaderSource = readFileSync(sourcePath('../config-loader.ts'), 'utf-8')
     // Should use execFileSync (array args, no shell) instead of execSync with template literal
     expect(cliSource).not.toMatch(/execSync\s*\(\s*`/)
     expect(loaderSource).not.toMatch(/execSync\s*\(\s*`/)

--- a/packages/valence/src/__tests__/fsd-scaffold.test.ts
+++ b/packages/valence/src/__tests__/fsd-scaffold.test.ts
@@ -15,14 +15,18 @@ vi.mock('node:child_process', () => ({
 const mockedWriteFile = vi.mocked(writeFile)
 const mockedMkdir = vi.mocked(mkdir)
 
+// Normalize path separators so `endsWith('a/b')`-style assertions hold on
+// Windows, where the CLI builds paths with `join` (backslashes) (#352).
+const toPosix = (p: unknown): string => String(p).replace(/\\/g, '/')
+
 function getWrittenFile (filename: string): string | undefined {
-  const call = mockedWriteFile.mock.calls.find(c => String(c[0]).endsWith(filename))
+  const call = mockedWriteFile.mock.calls.find(c => toPosix(c[0]).endsWith(filename))
   if (!call) return undefined
   return String(call[1])
 }
 
 function getDirsCreated (): string[] {
-  return mockedMkdir.mock.calls.map(c => String(c[0]))
+  return mockedMkdir.mock.calls.map(c => toPosix(c[0]))
 }
 
 describe('FSD scaffold during init', () => {
@@ -109,7 +113,7 @@ describe('FSD scaffold during init', () => {
   it('writes src/entities/posts/api/client.ts', async () => {
     await run(['init', 'test-app', '-y'])
     const client = mockedWriteFile.mock.calls.find(
-      c => String(c[0]).includes('entities/posts/api/client.ts')
+      c => toPosix(c[0]).includes('entities/posts/api/client.ts')
     )
     expect(client).toBeDefined()
     const content = String(client![1])

--- a/packages/valence/src/__tests__/page-routing.test.ts
+++ b/packages/valence/src/__tests__/page-routing.test.ts
@@ -1,23 +1,29 @@
 import { describe, it, expect } from 'vitest'
 import { resolvePageRoute, resolvePageRouteWithParam } from '../page-router.js'
 
+// These cases assert POSIX absolute-path resolution. The production resolver
+// is POSIX-coupled (node:path `normalize('/')` yields '\\' on win32), so they
+// only hold on POSIX hosts; CI (ubuntu) runs them. Rejection/traversal cases
+// below are platform-agnostic and always run (#352).
+const isWindows = process.platform === 'win32'
+
 describe('resolvePageRoute', () => {
-  it('maps / to src/pages/home/ui/index.html', () => {
+  it.skipIf(isWindows)('maps / to src/pages/home/ui/index.html', () => {
     const result = resolvePageRoute('/', '/tmp/project/src')
     expect(result).toBe('/tmp/project/src/pages/home/ui/index.html')
   })
 
-  it('maps /about to src/pages/about/ui/index.html', () => {
+  it.skipIf(isWindows)('maps /about to src/pages/about/ui/index.html', () => {
     const result = resolvePageRoute('/about', '/tmp/project/src')
     expect(result).toBe('/tmp/project/src/pages/about/ui/index.html')
   })
 
-  it('maps /posts to src/pages/posts/ui/index.html', () => {
+  it.skipIf(isWindows)('maps /posts to src/pages/posts/ui/index.html', () => {
     const result = resolvePageRoute('/posts', '/tmp/project/src')
     expect(result).toBe('/tmp/project/src/pages/posts/ui/index.html')
   })
 
-  it('maps /posts/:id to src/pages/posts/ui/detail.html', () => {
+  it.skipIf(isWindows)('maps /posts/:id to src/pages/posts/ui/detail.html', () => {
     const result = resolvePageRoute('/posts/abc-123', '/tmp/project/src')
     expect(result).toBe('/tmp/project/src/pages/posts/ui/detail.html')
   })
@@ -37,7 +43,7 @@ describe('resolvePageRoute', () => {
     expect(result).toBeNull()
   })
 
-  it('extracts route param from two-segment paths', () => {
+  it.skipIf(isWindows)('extracts route param from two-segment paths', () => {
     const result = resolvePageRouteWithParam('/posts/my-slug', '/tmp/project/src')
     expect(result).not.toBeNull()
     expect(result!.param).toBe('my-slug')
@@ -78,7 +84,7 @@ describe('resolvePageRoute', () => {
     expect(result).toBeNull()
   })
 
-  it('returns null param for single-segment paths', () => {
+  it.skipIf(isWindows)('returns null param for single-segment paths', () => {
     const result = resolvePageRouteWithParam('/about', '/tmp/project/src')
     expect(result).not.toBeNull()
     expect(result!.param).toBeNull()

--- a/packages/valence/src/__tests__/page-scaffold.test.ts
+++ b/packages/valence/src/__tests__/page-scaffold.test.ts
@@ -14,10 +14,14 @@ vi.mock('node:child_process', () => ({
 
 const mockedWriteFile = vi.mocked(writeFile)
 
+// Normalize path separators so `includes('a/b')` patterns hold on Windows,
+// where the CLI builds paths with `join` (backslashes) (#352).
+const toPosix = (p: unknown): string => String(p).replace(/\\/g, '/')
+
 function getWrittenFiles (pattern: string): Array<{ path: string; content: string }> {
   return mockedWriteFile.mock.calls
-    .filter(c => String(c[0]).includes(pattern))
-    .map(c => ({ path: String(c[0]), content: String(c[1]) }))
+    .filter(c => toPosix(c[0]).includes(pattern))
+    .map(c => ({ path: toPosix(c[0]), content: String(c[1]) }))
 }
 
 describe('page scaffold from collections', () => {

--- a/packages/valence/src/__tests__/regenerate.test.ts
+++ b/packages/valence/src/__tests__/regenerate.test.ts
@@ -17,8 +17,9 @@ vi.mock('node:fs/promises', () => ({
 
 vi.mock('node:fs', () => ({
   existsSync: vi.fn((path: string) => {
-    // Simulate that entity dirs already exist for 'posts'
-    return String(path).includes('entities/posts')
+    // Simulate that entity dirs already exist for 'posts'. Normalize
+    // separators so the match holds on Windows `join` paths (#352).
+    return String(path).replace(/\\/g, '/').includes('entities/posts')
   })
 }))
 

--- a/packages/valence/src/__tests__/static-serving.test.ts
+++ b/packages/valence/src/__tests__/static-serving.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { resolveStaticPath, resolveMimeType } from '@valencets/core/server'
 
+// resolveStaticPath's containment check joins with POSIX '/', so the Ok-path
+// output is POSIX-shaped; assert it only on POSIX hosts (CI runs it). The
+// rejection cases below are platform-agnostic and always run (#352).
+const isWindows = process.platform === 'win32'
+
 describe('static file serving reuse from core', () => {
-  it('resolveStaticPath resolves a valid path within root', () => {
+  it.skipIf(isWindows)('resolveStaticPath resolves a valid path within root', () => {
     const result = resolveStaticPath('/styles.css', '/tmp/public')
     expect(result.isOk()).toBe(true)
     if (result.isOk()) {

--- a/packages/valence/src/__tests__/tsx-loader.test.ts
+++ b/packages/valence/src/__tests__/tsx-loader.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// Resolve a sibling source file cross-platform: URL.pathname yields
+// "/C:/..." on Windows, which fs cannot open — fileURLToPath fixes it (#352).
+const sourcePath = (relative: string): string => fileURLToPath(new URL(relative, import.meta.url))
 
 describe('registerTsxLoader', () => {
   afterEach(() => {
@@ -25,10 +30,7 @@ describe('registerTsxLoader', () => {
   })
 
   it('source uses tsx/esm/api register, not node:module register', () => {
-    const source = readFileSync(
-      new URL('../config-loader.ts', import.meta.url).pathname.replace('/dist/', '/src/'),
-      'utf-8'
-    )
+    const source = readFileSync(sourcePath('../config-loader.ts'), 'utf-8')
     // Must dynamically import tsx/esm/api
     expect(source).toContain('tsx/esm/api')
     // Must call register() from the tsx API
@@ -38,10 +40,7 @@ describe('registerTsxLoader', () => {
   })
 
   it('source has idempotency guard', () => {
-    const source = readFileSync(
-      new URL('../config-loader.ts', import.meta.url).pathname.replace('/dist/', '/src/'),
-      'utf-8'
-    )
+    const source = readFileSync(sourcePath('../config-loader.ts'), 'utf-8')
     // Must have a guard variable and early return
     expect(source).toContain('tsxRegistered')
     expect(source).toMatch(/if\s*\(\s*tsxRegistered\s*\)\s*return/)
@@ -50,18 +49,12 @@ describe('registerTsxLoader', () => {
 
 describe('runDev registers tsx loader', () => {
   it('cli.ts imports registerTsxLoader from config-loader', () => {
-    const cliSource = readFileSync(
-      new URL('../cli.ts', import.meta.url).pathname.replace('/dist/', '/src/'),
-      'utf-8'
-    )
+    const cliSource = readFileSync(sourcePath('../cli.ts'), 'utf-8')
     expect(cliSource).toMatch(/import\s+\{[^}]*registerTsxLoader[^}]*\}\s+from\s+['"].\/config-loader\.js['"]/)
   })
 
   it('cli.ts awaits registerTsxLoader before loadUserConfig in runDev', () => {
-    const cliSource = readFileSync(
-      new URL('../cli.ts', import.meta.url).pathname.replace('/dist/', '/src/'),
-      'utf-8'
-    )
+    const cliSource = readFileSync(sourcePath('../cli.ts'), 'utf-8')
     // Must await the call
     const awaitIdx = cliSource.indexOf('await registerTsxLoader()')
     expect(awaitIdx).toBeGreaterThan(-1)

--- a/packages/valence/src/__tests__/user-route-map.test.ts
+++ b/packages/valence/src/__tests__/user-route-map.test.ts
@@ -301,9 +301,13 @@ describe('buildUserRouteMap', () => {
     expect(res.end).toHaveBeenCalledWith(expect.stringContaining('data-val-loader'))
   })
 
+  // Normalize separators so template path matching holds on Windows `join`
+  // paths (backslashes), keeping these assertions host-independent (#352).
+  const toPosix = (p: unknown): string => typeof p === 'string' ? p.replace(/\\/g, '/') : ''
+
   it('resolves multi-segment static routes to nested index templates', async () => {
     existsSyncMock.mockImplementation((path: unknown) =>
-      typeof path === 'string' && path.endsWith('/src/pages/blog/archive/ui/index.html')
+      toPosix(path).endsWith('/src/pages/blog/archive/ui/index.html')
     )
     readFileSyncMock.mockReturnValue('<html><body>archive</body></html>')
 
@@ -317,13 +321,14 @@ describe('buildUserRouteMap', () => {
     const res = makeRes()
     await h?.(req, res, {})
 
-    expect(readFileSyncMock).toHaveBeenCalledWith('/project/src/pages/blog/archive/ui/index.html', 'utf-8')
+    expect(toPosix(readFileSyncMock.mock.calls[0]?.[0])).toBe('/project/src/pages/blog/archive/ui/index.html')
+    expect(readFileSyncMock.mock.calls[0]?.[1]).toBe('utf-8')
     expect(res.end).toHaveBeenCalledWith(expect.stringContaining('archive'))
   })
 
   it('resolves mixed static and param routes to nested detail templates', async () => {
     existsSyncMock.mockImplementation((path: unknown) =>
-      typeof path === 'string' && path.endsWith('/src/pages/docs/history/ui/detail.html')
+      toPosix(path).endsWith('/src/pages/docs/history/ui/detail.html')
     )
     readFileSyncMock.mockReturnValue('<html><body>history</body></html>')
 
@@ -337,7 +342,8 @@ describe('buildUserRouteMap', () => {
     const res = makeRes()
     await h?.(req, res, { id: '42' })
 
-    expect(readFileSyncMock).toHaveBeenCalledWith('/project/src/pages/docs/history/ui/detail.html', 'utf-8')
+    expect(toPosix(readFileSyncMock.mock.calls[0]?.[0])).toBe('/project/src/pages/docs/history/ui/detail.html')
+    expect(readFileSyncMock.mock.calls[0]?.[1]).toBe('utf-8')
     expect(res.end).toHaveBeenCalledWith(expect.stringContaining('history'))
   })
 })


### PR DESCRIPTION
## Why

On a Windows checkout, 31 tests fail for host reasons while CI (ubuntu) is green, so contributors on Windows can't run the pre-push gate (`pnpm test:smoke`) without `--no-verify` (#352). Three independent root causes:

1. **Source-scanning tests** compared source read with CRLF against `\n`-containing substrings, or resolved sibling source files via `new URL(...).pathname` (which yields the fs-unopenable `/C:/...` on win32).
2. **Path-string assertions** matched `join`-built paths (backslashes on win32) against forward-slash `endsWith`/`includes`/exact strings.
3. **POSIX path-resolution semantics** — `resolveStaticPath` and `page-router` join/normalize with POSIX `/` (`node:path` `normalize('/')` → `\` on win32), so their exact-output assertions are POSIX-only.

## What (test-only — zero production impact)

- **Cross-platform, still runs everywhere:**
  - CRLF → LF normalization before multi-line substring assertions (`core/form-enhance`, `core/push-state`).
  - `fileURLToPath(new URL(...))` instead of `.pathname.replace('/dist/','/src/')` for sibling source reads (`valence/cli`, `valence/tsx-loader`).
  - Backslash → `/` normalization on recorded mock path args (`valence/fsd-scaffold`, `page-scaffold`, `regenerate` existsSync mock, `user-route-map` template matching + fs-call assertions).
- **POSIX-only, guarded with `it.skipIf(process.platform === 'win32')` + a comment** (CI on ubuntu still runs them; rejection/traversal cases stay platform-agnostic and always run):
  - `core/static-files` (2), `valence/static-serving` (1) — `resolveStaticPath` Ok-path output shape.
  - `valence/page-routing` (6) — `resolvePageRoute` POSIX absolute-path resolution.

## Validation

- **`pnpm test` (test:smoke) now green on Windows across all 12 packages** (was 31 failing). Core `774 passed / 2 skipped`, valence `569 passed / 7 skipped`; everything else unchanged.
- `pnpm build`, `pnpm lint`, `bash scripts/check-banned-patterns.sh`, TDD-sequence check — all green.

## Discovered (out of scope here)

`page-router.ts` and `resolveStaticPath`'s containment check are genuinely POSIX-coupled: `node:path` `normalize('/')` → `\` on win32 makes `resolvePageRoute` return `null` for every route, so `valence dev` would not resolve pages on a Windows host. This is a real runtime-portability gap, deliberately left to a separate change per #352's test-only scope — flagging for a follow-up decision.

Closes #352.