### PR TITLE
feat(ui): defineComponent — user-authored Web Components, fully Valence (Phase 1) (#373)

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1,0 +1,124 @@
+# Authoring Web Components
+
+Valence's component model **is** the Web Component. There is no virtual DOM and
+no `.valence`/SFC compiler — a template compiler plus a runtime is the exact
+layer Valence bets against. Instead, `defineComponent()` is a thin declarative
+factory over the framework's `ValElement` base, so a component you author
+inherits — for free — declarative hydration, telemetry, i18n, design tokens, and
+ARIA, and gains reactive signals with `data-bind` templating.
+
+It lives at the subpath `@valencets/ui/component`. The main `@valencets/ui`
+entry (the presentational `val-*` primitives) stays free of any reactive/store
+import, so public pages never pull it onto the 14 kB critical path.
+
+## A first component
+
+```ts
+// src/components/counter.ts
+import { defineComponent, signal } from '@valencets/ui/component'
+
+export const Counter = defineComponent({
+  tag: 'x-counter',                                   // must contain a hyphen
+  props: { start: { type: 'number', default: 0 } },   // typed + reflected
+  styles: `button { font: var(--val-text-sm) var(--val-font-sans) }`,
+  template: `
+    <button data-bind="onclick:increment">
+      <span data-bind="text:label"></span>:
+      <span data-bind="text:count"></span>
+    </button>`,
+  setup ({ props, ctx }) {
+    const count = signal(props.start)                 // props.start is `number`
+    return {
+      count,
+      label: 'Count',
+      increment: () => { count.value = count.value + 1 }
+    }
+  }
+})
+```
+
+Register it (Phase 3 will do this for you from config):
+
+```ts
+Counter.define()   // idempotent customElements.define('x-counter', …)
+```
+
+```html
+<x-counter start="5"></x-counter>
+```
+
+## The pieces
+
+### `tag`
+The custom-element name. Must contain a hyphen (the platform rule). This is also
+the key codegen will use to derive typed intrinsic elements (Phase 3).
+
+### `props`
+A declarative, typed attribute schema. Each entry is `{ type, default? }` with
+`type` one of `'string' | 'number' | 'boolean'`. Attributes are coerced to that
+type and passed to `setup()` as `props`, fully typed from the schema:
+
+| type | attribute → value |
+| --- | --- |
+| `string` | the raw attribute, or `default` when absent |
+| `number` | `Number(attr)`, or `Number(default)` when absent |
+| `boolean` | present and not `"false"` → `true`; absent → `default` |
+
+### `template`
+A plain HTML string. Interactivity is wired with **`data-bind`** markers — the
+same `data-*` mental model stores use — resolved against what `setup()` returns.
+No new expression language, no `{{ }}`.
+
+| marker | binds to | example |
+| --- | --- | --- |
+| `text:key` | element text content | `<span data-bind="text:count">` |
+| `value:key` | two-way input value | `<input data-bind="value:name">` |
+| `checked:key` | two-way checkbox | `<input type="checkbox" data-bind="checked:agree">` |
+| `visible:key` | `display` from a boolean | `<div data-bind="visible:isOpen">` |
+| `class:name:key` | toggle a class from a boolean | `data-bind="class:active:isOpen"` |
+| `attr:name:key` | set/remove an attribute | `data-bind="attr:aria-expanded:isOpen"` |
+| `on<event>:key` | an event handler | `data-bind="onclick:increment"` |
+
+Multiple bindings on one element are comma-separated:
+`data-bind="text:count, class:hot:isHot"`.
+
+Signal bindings are reactive through `@valencets/reactive` `bind()`: update a
+signal in a handler and the DOM follows. `on*` markers map to
+`addEventListener`; all bindings are torn down automatically on disconnect.
+
+### `styles`
+Optional scoped CSS injected into the shadow root. Use design tokens
+(`var(--val-*)`) — they cross the shadow boundary and respond to theme changes.
+
+### `shadow`
+Shadow DOM is on by default. Set `shadow: false` for a light-DOM component (for
+example, one that must be styled by page-level CSS).
+
+### `setup({ props, ctx })`
+Runs once at hydration. Create signals, derive values, and return a map whose
+keys the `data-bind` markers reference — signals for state, functions for
+handlers. `ctx` carries the ValElement surface:
+
+- `ctx.host` — the element instance (escape hatch).
+- `ctx.emit(action, detail?)` — fire a `val:interaction` telemetry event.
+- `ctx.locale` — the current locale from the shared observer.
+
+## Hydration directives
+
+Because the component extends `ValElement`, the declarative hydration directives
+work out of the box — the element stays inert HTML until the condition fires:
+
+```html
+<x-counter hydrate:visible></x-counter>
+<x-panel hydrate:media="(min-width: 1024px)"></x-panel>
+```
+
+## Roadmap
+
+- **Store wiring** — `ctx.store('cart')` will return the live, schema-driven
+  store client (signals + mutations), so components join the same
+  server-is-truth, optimistic, SSE-reconciled state as the rest of the app.
+- **Config + codegen** — declare `components: [Counter]` in `valence.config.ts`;
+  codegen registers them on the client and emits typed intrinsic elements.
+
+Tracked in the `defineComponent` issue (#373).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./component": {
+      "import": "./dist/component/index.js",
+      "types": "./dist/component/index.d.ts"
+    },
     "./tokens/primitives.css": "./dist/tokens/primitives.css",
     "./tokens/semantic.css": "./dist/tokens/semantic.css",
     "./tailwind": {
@@ -19,6 +23,9 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "@valencets/reactive": "workspace:*"
+  },
   "scripts": {
     "build": "tsc && cp src/tokens/*.css dist/tokens/",
     "test": "vitest run",

--- a/packages/ui/src/component/__tests__/define-component.test.ts
+++ b/packages/ui/src/component/__tests__/define-component.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { defineComponent, signal } from '../index.js'
+
+let counter = 0
+const uniqueTag = (): string => `x-comp-${++counter}`
+
+describe('defineComponent', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    host.remove()
+  })
+
+  const mount = (tag: string, attrs?: Readonly<Record<string, string>>): HTMLElement => {
+    const el = document.createElement(tag)
+    if (attrs !== undefined) {
+      for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v)
+    }
+    host.appendChild(el)
+    return el
+  }
+
+  it('returns the tag, an element constructor, and an idempotent define()', () => {
+    const tag = uniqueTag()
+    const dc = defineComponent({ tag, template: '<p>hi</p>' })
+    expect(dc.tag).toBe(tag)
+    expect(typeof dc.element).toBe('function')
+    // Importing/creating a definition must not auto-register (side-effect free).
+    expect(customElements.get(tag)).toBeUndefined()
+    dc.define()
+    expect(customElements.get(tag)).toBe(dc.element)
+    dc.define() // second call is a no-op, not a re-definition error
+    expect(customElements.get(tag)).toBe(dc.element)
+  })
+
+  it('clones the template into a shadow root and injects scoped styles', () => {
+    const tag = uniqueTag()
+    defineComponent({ tag, template: '<p class="msg">hi</p>', styles: '.msg{color:red}' }).define()
+    const el = mount(tag)
+    expect(el.shadowRoot).not.toBeNull()
+    expect(el.shadowRoot!.querySelector('.msg')?.textContent).toBe('hi')
+    expect(el.shadowRoot!.querySelector('style')?.textContent).toContain('color:red')
+  })
+
+  it('renders into light DOM when shadow is false', () => {
+    const tag = uniqueTag()
+    defineComponent({ tag, shadow: false, template: '<p class="l">hi</p>' }).define()
+    const el = mount(tag)
+    expect(el.shadowRoot).toBeNull()
+    expect(el.querySelector('.l')?.textContent).toBe('hi')
+  })
+
+  it('parses props with type coercion and defaults into setup', () => {
+    const tag = uniqueTag()
+    let captured: { s: unknown; n: unknown; b: unknown } | null = null
+    defineComponent({
+      tag,
+      props: {
+        label: { type: 'string', default: 'hi' },
+        num: { type: 'number', default: 3 },
+        flag: { type: 'boolean', default: false }
+      },
+      template: '<p></p>',
+      setup ({ props }) {
+        captured = { s: props.label, n: props.num, b: props.flag }
+        return {}
+      }
+    }).define()
+    mount(tag, { num: '42', flag: '' })
+    expect(captured).toEqual({ s: 'hi', n: 42, b: true })
+  })
+
+  it('binds text to a signal and reacts to event handlers via data-bind', () => {
+    const tag = uniqueTag()
+    defineComponent({
+      tag,
+      props: { start: { type: 'number', default: 0 } },
+      template: '<button data-bind="onclick:inc"><span class="c" data-bind="text:count"></span></button>',
+      setup ({ props }) {
+        const count = signal(props.start)
+        return { count, inc: () => { count.value = count.value + 1 } }
+      }
+    }).define()
+    const el = mount(tag, { start: '5' })
+    const span = el.shadowRoot!.querySelector('.c')!
+    expect(span.textContent).toBe('5')
+    ;(el.shadowRoot!.querySelector('button') as HTMLElement).click()
+    expect(span.textContent).toBe('6')
+  })
+
+  it('toggles classes reactively from a boolean signal', () => {
+    const tag = uniqueTag()
+    let openRef: { value: boolean } | null = null
+    defineComponent({
+      tag,
+      template: '<div class="box" data-bind="class:open:isOpen"></div>',
+      setup () {
+        const isOpen = signal(false)
+        openRef = isOpen
+        return { isOpen }
+      }
+    }).define()
+    const el = mount(tag)
+    const box = el.shadowRoot!.querySelector('.box')!
+    expect(box.classList.contains('open')).toBe(false)
+    openRef!.value = true
+    expect(box.classList.contains('open')).toBe(true)
+  })
+
+  it('two-way binds an input value to a signal', () => {
+    const tag = uniqueTag()
+    let nameRef: { value: string } | null = null
+    defineComponent({
+      tag,
+      template: '<input data-bind="value:name">',
+      setup () {
+        const name = signal('a')
+        nameRef = name
+        return { name }
+      }
+    }).define()
+    const el = mount(tag)
+    const input = el.shadowRoot!.querySelector('input') as HTMLInputElement
+    expect(input.value).toBe('a')
+    nameRef!.value = 'b'
+    expect(input.value).toBe('b')
+    input.value = 'typed'
+    input.dispatchEvent(new Event('input'))
+    expect(nameRef!.value).toBe('typed')
+  })
+
+  it('disposes bindings on disconnect so signals stop driving the DOM', () => {
+    const tag = uniqueTag()
+    let msgRef: { value: string } | null = null
+    defineComponent({
+      tag,
+      template: '<span data-bind="text:msg"></span>',
+      setup () {
+        const msg = signal('x')
+        msgRef = msg
+        return { msg }
+      }
+    }).define()
+    const el = mount(tag)
+    const span = el.shadowRoot!.querySelector('span')!
+    expect(span.textContent).toBe('x')
+    el.remove()
+    msgRef!.value = 'y'
+    expect(span.textContent).toBe('x')
+  })
+
+  it('inherits ValElement telemetry — setup ctx.emit dispatches an interaction event', () => {
+    const tag = uniqueTag()
+    let emit: ((action: string) => void) | null = null
+    defineComponent({
+      tag,
+      template: '<p>hi</p>',
+      setup ({ ctx }) {
+        emit = (action: string) => { ctx.emit(action) }
+        return {}
+      }
+    }).define()
+    const el = mount(tag)
+    const events: string[] = []
+    el.addEventListener('val:interaction', (e) => {
+      events.push((e as CustomEvent<{ action: string }>).detail.action)
+    })
+    emit!('poke')
+    expect(events).toContain('poke')
+  })
+})

--- a/packages/ui/src/component/define-component.ts
+++ b/packages/ui/src/component/define-component.ts
@@ -1,0 +1,270 @@
+// defineComponent — the factory that makes a user-authored Web Component
+// "fully Valence" (#373). It is a thin declarative wrapper over ValElement, so
+// a user's component inherits hydration directives, telemetry, i18n, design
+// tokens, and ARIA for free, and gains reactive signals + data-bind templating.
+//
+// The component model IS the Web Component — no VDOM, no SFC compiler. The
+// template is a plain string with `data-bind` markers resolved against the
+// signals and handlers that setup() returns, reusing the same `data-*` mental
+// model and the same reactive bind() plumbing that stores use.
+
+import { ValElement } from '../core/val-element.js'
+import { bind, computed } from '@valencets/reactive'
+import type { Signal, ReadonlySignal, BindingMap } from '@valencets/reactive'
+
+export type PropType = 'string' | 'number' | 'boolean'
+
+export interface ComponentPropSpec {
+  readonly type: PropType
+  readonly default?: string | number | boolean
+}
+
+type PropRuntime<S extends ComponentPropSpec> =
+  S['type'] extends 'number' ? number
+    : S['type'] extends 'boolean' ? boolean
+      : string
+
+type PropsOf<D extends Readonly<Record<string, ComponentPropSpec>>> = {
+  readonly [K in keyof D]: PropRuntime<D[K]>
+}
+
+/** The declarative surface handed to setup(), mirroring ValElement's pillars. */
+export interface ComponentContext {
+  readonly host: HTMLElement
+  /** Fire a telemetry interaction (val:interaction) — see ValElement. */
+  readonly emit: (action: string, detail?: Record<string, string | number | boolean>) => void
+  /** Current locale from the shared locale observer. */
+  readonly locale: string
+}
+
+export interface SetupArgs<P> {
+  readonly props: P
+  readonly ctx: ComponentContext
+}
+
+/** setup() returns named signals (bound to text/value/…) and handlers (bound to on*). */
+export type SetupResult = { readonly [key: string]: unknown }
+
+export interface ComponentDefinition<D extends Readonly<Record<string, ComponentPropSpec>>> {
+  /** Custom-element tag — must contain a hyphen. */
+  readonly tag: string
+  readonly props?: D
+  /** Template string; `data-bind` markers wire it to setup()'s result. */
+  readonly template: string
+  /** Scoped CSS injected into the shadow root (token-aware). */
+  readonly styles?: string
+  /** Shadow DOM on by default; set false for light-DOM components. */
+  readonly shadow?: boolean
+  readonly setup?: (args: SetupArgs<PropsOf<D>>) => SetupResult
+}
+
+export interface DefinedComponent {
+  readonly tag: string
+  readonly element: CustomElementConstructor
+  /** Idempotent customElements.define(tag, element). */
+  readonly define: () => void
+}
+
+// --- data-bind parsing ---
+
+interface Directive {
+  readonly kind: string
+  readonly name: string | null
+  readonly key: string
+}
+
+// "text:count, class:open:isOpen, onclick:inc" → structured directives.
+function parseBindings (raw: string): readonly Directive[] {
+  const out: Directive[] = []
+  for (const token of raw.split(',')) {
+    const parts = token.trim().split(':').map(p => p.trim())
+    const kind = parts[0]
+    const a = parts[1]
+    const b = parts[2]
+    if (kind === undefined || kind === '' || a === undefined || a === '') continue
+    if (parts.length === 2) {
+      out.push({ kind, name: null, key: a })
+    } else if (parts.length === 3 && b !== undefined && b !== '') {
+      out.push({ kind, name: a, key: b })
+    }
+  }
+  return out
+}
+
+// --- value resolution ---
+
+function isReadableSignal (value: unknown): boolean {
+  return typeof value === 'object' && value !== null &&
+    'peek' in value && typeof (value as { peek?: unknown }).peek === 'function'
+}
+
+function toText (value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return String(value)
+}
+
+// A mutable BindingMap we assemble per element, then hand to bind().
+interface MutableBindingMap {
+  text?: ReadonlySignal<string>
+  value?: Signal<string>
+  checked?: Signal<boolean>
+  visible?: ReadonlySignal<boolean>
+  class?: { [name: string]: ReadonlySignal<boolean> }
+  attr?: { [name: string]: ReadonlySignal<string | null> }
+}
+
+function addSignalBinding (map: MutableBindingMap, d: Directive, raw: unknown): void {
+  const sig = raw as ReadonlySignal<unknown>
+  if (d.kind === 'text') {
+    map.text = computed(() => toText(sig.value))
+    return
+  }
+  if (d.kind === 'value') {
+    map.value = raw as Signal<string>
+    return
+  }
+  if (d.kind === 'checked') {
+    map.checked = raw as Signal<boolean>
+    return
+  }
+  if (d.kind === 'visible') {
+    map.visible = computed(() => Boolean(sig.value))
+    return
+  }
+  if (d.kind === 'class' && d.name !== null) {
+    const bag = map.class ?? {}
+    bag[d.name] = computed(() => Boolean(sig.value))
+    map.class = bag
+    return
+  }
+  if (d.kind === 'attr' && d.name !== null) {
+    const bag = map.attr ?? {}
+    bag[d.name] = computed(() => {
+      const v = sig.value
+      return (v === null || v === undefined) ? null : toText(v)
+    })
+    map.attr = bag
+  }
+}
+
+const EVENT_PREFIX = 'on'
+
+function wireElement (node: Element, directives: readonly Directive[], result: SetupResult): () => void {
+  const map: MutableBindingMap = {}
+  const disposers: Array<() => void> = []
+
+  for (const d of directives) {
+    const raw = result[d.key]
+    if (d.kind.startsWith(EVENT_PREFIX) && typeof raw === 'function') {
+      const type = d.kind.slice(EVENT_PREFIX.length)
+      const handler = raw as (e: Event) => void
+      node.addEventListener(type, handler)
+      disposers.push(() => { node.removeEventListener(type, handler) })
+      continue
+    }
+    if (isReadableSignal(raw)) {
+      addSignalBinding(map, d, raw)
+    }
+  }
+
+  const stop = bind(node, map as BindingMap)
+  disposers.push(stop)
+  return () => { for (const dispose of disposers) dispose() }
+}
+
+// --- the generated element class ---
+
+function coerceProp (spec: ComponentPropSpec, attr: string | null): string | number | boolean {
+  if (spec.type === 'number') {
+    return attr === null ? Number(spec.default ?? 0) : Number(attr)
+  }
+  if (spec.type === 'boolean') {
+    return attr === null ? Boolean(spec.default ?? false) : attr !== 'false'
+  }
+  return attr === null ? String(spec.default ?? '') : attr
+}
+
+function buildElementClass<D extends Readonly<Record<string, ComponentPropSpec>>> (
+  definition: ComponentDefinition<D>
+): CustomElementConstructor {
+  const propEntries = Object.entries(definition.props ?? {})
+  const useShadow = definition.shadow !== false
+
+  class GeneratedComponent extends ValElement {
+    private _disposers: Array<() => void> = []
+
+    constructor () {
+      super({ shadow: useShadow })
+    }
+
+    protected createTemplate (): HTMLTemplateElement {
+      const template = document.createElement('template')
+      const style = definition.styles !== undefined ? `<style>${definition.styles}</style>` : ''
+      template.innerHTML = style + definition.template
+      return template
+    }
+
+    connectedCallback (): void {
+      super.connectedCallback()
+      // Wait for deferred hydration directives (hydrate:idle/visible/media) to
+      // resolve; ValElement re-invokes this once the element is live.
+      if (!this.hydrated) return
+      if (this._disposers.length > 0) return
+      this._wire()
+    }
+
+    disconnectedCallback (): void {
+      for (const dispose of this._disposers) dispose()
+      this._disposers = []
+      super.disconnectedCallback()
+    }
+
+    private _readProps (): PropsOf<D> {
+      const values: { [key: string]: string | number | boolean } = {}
+      for (const [name, spec] of propEntries) {
+        values[name] = coerceProp(spec, this.getAttribute(name))
+      }
+      return values as PropsOf<D>
+    }
+
+    private _wire (): void {
+      const root: ParentNode = this.shadowRoot ?? this
+      const ctx: ComponentContext = {
+        host: this,
+        emit: (action, detail) => { this.emitInteraction(action, detail) },
+        locale: this.locale
+      }
+      const result = definition.setup !== undefined
+        ? definition.setup({ props: this._readProps(), ctx })
+        : {}
+      for (const node of root.querySelectorAll('[data-bind]')) {
+        const raw = node.getAttribute('data-bind')
+        if (raw === null) continue
+        this._disposers.push(wireElement(node, parseBindings(raw), result))
+      }
+    }
+  }
+
+  Object.defineProperty(GeneratedComponent, 'observedAttributes', {
+    value: propEntries.map(([name]) => name)
+  })
+  return GeneratedComponent
+}
+
+export function defineComponent<D extends Readonly<Record<string, ComponentPropSpec>> = Record<string, never>> (
+  definition: ComponentDefinition<D>
+): DefinedComponent {
+  const element = buildElementClass(definition)
+  const tag = definition.tag
+  return {
+    tag,
+    element,
+    define: () => {
+      if (customElements.get(tag) === undefined) {
+        customElements.define(tag, element)
+      }
+    }
+  }
+}

--- a/packages/ui/src/component/index.ts
+++ b/packages/ui/src/component/index.ts
@@ -1,0 +1,22 @@
+// @valencets/ui/component — the defineComponent authoring surface (#373).
+//
+// This subpath takes the @valencets/reactive edge so user components get
+// signals + bind() here, while the main @valencets/ui shell stays free of any
+// reactive/store import — presentational val-* never drag it onto public pages.
+// reactive is itself zero-dependency, so this introduces no third-party JS.
+
+export { defineComponent } from './define-component.js'
+export type {
+  ComponentDefinition,
+  ComponentPropSpec,
+  ComponentContext,
+  SetupArgs,
+  SetupResult,
+  DefinedComponent,
+  PropType
+} from './define-component.js'
+
+// Re-exported so a component module imports everything from one place:
+//   import { defineComponent, signal, computed } from '@valencets/ui/component'
+export { signal, computed, effect, batch, untracked } from '@valencets/reactive'
+export type { Signal, ReadonlySignal, SignalOptions } from '@valencets/reactive'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@valencets/reactive':
+        specifier: workspace:*
+        version: link:../reactive
       tailwindcss:
         specifier: '>=3.4.0'
         version: 4.2.2


### PR DESCRIPTION
## Why

User-authored Web Components should be as first-class as collections/stores/routes — authored as a declarative object, everything derived. The component model stays the Web Component: **no VDOM, no `.valence`/SFC compiler** (the layer Valence bets against). This lands **Phase 1** of #373: the factory itself.

## What

New subpath **`@valencets/ui/component`** exporting `defineComponent()`, a thin declarative wrapper over the existing `ValElement`. A user component inherits hydration directives, telemetry, i18n, tokens, and ARIA for free, and gains reactive signals + `data-bind` templating:

```ts
import { defineComponent, signal } from '@valencets/ui/component'

export const Counter = defineComponent({
  tag: 'x-counter',
  props: { start: { type: 'number', default: 0 } },
  template: `<button data-bind="onclick:inc"><span data-bind="text:count"></span></button>`,
  setup ({ props }) {
    const count = signal(props.start)          // props.start typed `number`
    return { count, inc: () => { count.value++ } }
  }
})
```

- **Typed props** inferred from the `{ type, default }` schema (`string`/`number`/`boolean`), coerced from attributes.
- **`data-bind` templating** — `text:`, `value:`, `checked:`, `visible:`, `class:name:`, `attr:name:`, `on<event>:` — resolved against `setup()`'s returned signals/handlers via the existing `@valencets/reactive` `bind()` + `addEventListener`. Same `data-*` model stores use; no new expression language.
- **Shadow DOM + scoped `styles`** (token-aware) by default; `shadow:false` for light DOM.
- **Idempotent `define()`**; creating a definition is side-effect-free (no auto-register).
- Bindings are **torn down on disconnect** (no leaks).
- `ctx.emit` / `ctx.locale` expose the ValElement surface to `setup()`.

## Design decisions (resolving #369's open questions)

- **Home:** subpath `@valencets/ui/component`, **no new package**. The main `@valencets/ui` `.` entry imports nothing from it → `val-*`-only consumers stay byte-identical after tree-shaking.
- **`reactive` fold:** keep it **standalone**; take the edge at the subpath. `reactive` is **zero-dependency**, so `ui` gaining it introduces **zero third-party JS** — the "can't leak third-party JS onto a public page" guarantee holds.
- **`zod`/store edge:** deferred to Phase 2 as an optional-peer edge — it never touches the 14 kB public shell.

## Tests

`packages/ui/src/component/__tests__/define-component.test.ts` (9, happy-dom): registration/idempotency, shadow vs light DOM + styles, prop coercion/defaults, reactive text + event handlers, class toggling, two-way input value, disconnect disposal, and `ctx.emit` telemetry.

## Validation

- `pnpm build` (full workspace, incl. cms/valence which depend on ui), `pnpm lint`, `bash scripts/check-banned-patterns.sh`, TDD-sequence — all green.
- Full `@valencets/ui` suite: **520 passed**. `ui.api.md` unchanged (the subpath is additive; the main frozen surface is untouched).

## Follow-ups (tracked in #373)

- **Phase 2 — store wiring:** `ctx.store('cart')` returns the live `StoreClient` (signals/mutations), joining the SSE/optimistic/rebased state.
- **Phase 3 — config + codegen:** `components: [...]` in `valence.config.ts`; codegen registers on the client + emits typed intrinsic-element types; SSR the inert markup, hydrate on the client.

Part of #373.